### PR TITLE
Add default shell to Makefile for operator

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -26,6 +26,8 @@ endif
 all: manager
 
 # Run tests
+# Set default shell as bash
+SHELL := /bin/bash
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 test: generate fmt vet manifests
 	mkdir -p $(ENVTEST_ASSETS_DIR)


### PR DESCRIPTION
Fix was used in https://github.com/operator-framework/operator-sdk/pull/4204 to enable tests on ubuntu