### PR TITLE
Add generated manifests to operator

### DIFF
--- a/operator/config/crd/bases/tailing-sidecar.sumologic.com_tailingsidecars.yaml
+++ b/operator/config/crd/bases/tailing-sidecar.sumologic.com_tailingsidecars.yaml
@@ -1,0 +1,58 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: tailingsidecars.tailing-sidecar.sumologic.com
+spec:
+  group: tailing-sidecar.sumologic.com
+  names:
+    kind: TailingSidecar
+    listKind: TailingSidecarList
+    plural: tailingsidecars
+    singular: tailingsidecar
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: TailingSidecar is the Schema for the tailingsidecars API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: TailingSidecarSpec defines the desired state of TailingSidecar
+          properties:
+            foo:
+              description: Foo is an example field of TailingSidecar. Edit TailingSidecar_types.go
+                to remove/update
+              type: string
+          type: object
+        status:
+          description: TailingSidecarStatus defines the observed state of TailingSidecar
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -1,0 +1,28 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role
+rules:
+- apiGroups:
+  - tailing-sidecar.sumologic.com
+  resources:
+  - tailingsidecars
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - tailing-sidecar.sumologic.com
+  resources:
+  - tailingsidecars/status
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
Add `CustomResourceDefinition` and `ClusterRole` for TailingSidecar. 
Generated using `make manifests`, more [information](https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/#define-the-api)