### PR TITLE
Change MutatingWebhook configuration

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -36,6 +36,9 @@ patchesStrategicMerge:
 # crd/kustomization.yaml
 - manager_webhook_patch.yaml
 
+# [WEBHOOK] To add reinvocationPolicy, namespaceSelector, objectSelector, adjust it if needed
+#- webhook_patch.yaml
+
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection

--- a/operator/config/default/webhook_patch.yaml
+++ b/operator/config/default/webhook_patch.yaml
@@ -1,0 +1,16 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+  name: tailing-sidecar.sumologic.com
+  reinvocationPolicy: IfNeeded
+  ## enable the example below to limit to namespaces with specific labels only
+  # namespaceSelector:
+  #   matchLabels:
+  #     tailing-sidecar: "true"
+  ## enable the example below to limit to objects with specific labels only
+  # objectSelector:
+  #   matchLabels:
+  #     tailing-sidecar: "true"

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -12,8 +12,8 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /add-tailing-sidecars-v1-pod
-  failurePolicy: Fail
-  name: mpod.kb.io
+  failurePolicy: Ignore
+  name: tailing-sidecar.sumologic.com
   rules:
   - apiGroups:
     - ""

--- a/operator/handler/handler.go
+++ b/operator/handler/handler.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// +kubebuilder:webhook:path=/add-tailing-sidecars-v1-pod,mutating=true,failurePolicy=fail,groups="",resources=pods,verbs=create;update,versions=v1,name=mpod.kb.io
+// +kubebuilder:webhook:path=/add-tailing-sidecars-v1-pod,mutating=true,failurePolicy=ignore,groups="",resources=pods,verbs=create;update,versions=v1,name=tailing-sidecar.sumologic.com
 
 const (
 	sidecarEnv             = "PATH_TO_TAIL"


### PR DESCRIPTION
- Change webhook config name to `tailing-sidecar.sumologic.com`
- Change failurePolicy to Ignore
- Add kustomize patch to set reinvocationPolicy, namespaceSelector, objectSelector

Tested scenario:
1.  Deploy operator with - webhook_patch.yaml

2. Deploy examples
```
make deploy-examples
```

3. Check resources
```
kubectl get pods -n tailing-sidecar-system 
NAME                                          READY   STATUS    RESTARTS   AGE
tailing-sidecar-operator-7978d4956f-fl55q     2/2     Running   0          84m
pod-with-annotations                          1/1     Running   0          22s
deployment-with-annotations-f44946f4c-d6rl5   1/1     Running   0          21s
deployment-with-annotations-f44946f4c-9tfnd   1/1     Running   0          21s
deployment-with-annotations-f44946f4c-pwhhx   1/1     Running   0          21s
statefulset-with-annotations-0                1/1     Running   0          21s
daemonset-with-annotations-jfhlm              1/1     Running   0          21s
pod-without-annotations                       1/1     Running   0          21s
statefulset-with-annotations-1                1/1     Running   0          10s
statefulset-with-annotations-2                1/1     Running   0          6s
```
and `make check-examples`

4. Add label to all example resources

```
template:
    metadata:
      labels:
        tailing-sidecar: 'true'
```

5. Apply changes in example resources
```kubectl apply -f config/samples/tailing-sidecar_v1_tailingsidecar.yaml -n tailing-sidecar-system --force
kubectl apply -f examples/pod_with_annotations.yaml --force
kubectl apply -f examples/statefulset_with_annotations.yaml --force
kubectl apply -f examples/deployment_with_annotations.yaml --force
kubectl apply -f examples/daemonset_with_annotations.yaml --force
kubectl apply -f examples/pod_without_annotations.yaml --force
```
6.
```
make check-examples
kubectl get all -n tailing-sidecar-system
NAME                                              READY   STATUS    RESTARTS   AGE
pod/tailing-sidecar-operator-7978d4956f-fl55q     2/2     Running   0          99m
pod/pod-without-annotations                       1/1     Running   0          14m
pod/deployment-with-annotations-8c775686c-q54kz   4/4     Running   0          2m26s
pod/pod-with-annotations                          4/4     Running   0          2m27s
pod/deployment-with-annotations-8c775686c-8vj2p   4/4     Running   0          2m18s
pod/deployment-with-annotations-8c775686c-p7jjk   4/4     Running   0          2m14s
pod/statefulset-with-annotations-2                4/4     Running   0          107s
pod/daemonset-with-annotations-bs6m6              4/4     Running   0          107s
pod/statefulset-with-annotations-1                4/4     Running   0          71s
pod/statefulset-with-annotations-0                4/4     Running   0          35s

NAME                                               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
service/tailing-sidecar-operator-metrics-service   ClusterIP   10.152.183.76   <none>        8443/TCP   99m
service/tailing-sidecar-webhook-service            ClusterIP   10.152.183.61   <none>        443/TCP    99m

NAME                                        DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
daemonset.apps/daemonset-with-annotations   1         1         1       1            1           <none>          14m

NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/tailing-sidecar-operator      1/1     1            1           99m
deployment.apps/deployment-with-annotations   3/3     3            3           14m

NAME                                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/tailing-sidecar-operator-7978d4956f     1         1         1       99m
replicaset.apps/deployment-with-annotations-8c775686c   3         3         3       2m26s
replicaset.apps/deployment-with-annotations-f44946f4c   0         0         0       14m

NAME                                            READY   AGE
statefulset.apps/statefulset-with-annotations   3/3     14m
kubectl logs pod-with-annotations tailing-sidecar0 -n tailing-sidecar-system --tail 5
example2: 139 Mon Mar  8 12:42:43 UTC 2021
example2: 140 Mon Mar  8 12:42:44 UTC 2021
example2: 141 Mon Mar  8 12:42:45 UTC 2021
example2: 142 Mon Mar  8 12:42:46 UTC 2021
example2: 143 Mon Mar  8 12:42:47 UTC 2021
kubectl logs pod-with-annotations tailing-sidecar1 -n tailing-sidecar-system --tail 5
example0: 139 Mon Mar  8 12:42:43 UTC 2021
example0: 140 Mon Mar  8 12:42:44 UTC 2021
example0: 141 Mon Mar  8 12:42:45 UTC 2021
example0: 142 Mon Mar  8 12:42:46 UTC 2021
example0: 143 Mon Mar  8 12:42:47 UTC 2021
kubectl logs pod-with-annotations tailing-sidecar2 -n tailing-sidecar-system --tail 5
example1: 139 Mon Mar  8 12:42:43 UTC 2021
example1: 140 Mon Mar  8 12:42:44 UTC 2021
example1: 141 Mon Mar  8 12:42:45 UTC 2021
example1: 142 Mon Mar  8 12:42:46 UTC 2021
example1: 143 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-q54kz \
        tailing-sidecar0 -n tailing-sidecar-system --tail 5
example2: 137 Mon Mar  8 12:42:42 UTC 2021
example2: 138 Mon Mar  8 12:42:43 UTC 2021
example2: 139 Mon Mar  8 12:42:44 UTC 2021
example2: 140 Mon Mar  8 12:42:45 UTC 2021
example2: 141 Mon Mar  8 12:42:46 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-q54kz \
        tailing-sidecar1 -n tailing-sidecar-system --tail 5
example0: 137 Mon Mar  8 12:42:42 UTC 2021
example0: 138 Mon Mar  8 12:42:43 UTC 2021
example0: 139 Mon Mar  8 12:42:44 UTC 2021
example0: 140 Mon Mar  8 12:42:45 UTC 2021
example0: 141 Mon Mar  8 12:42:46 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-q54kz \
        tailing-sidecar2 -n tailing-sidecar-system --tail 5
example1: 137 Mon Mar  8 12:42:42 UTC 2021
example1: 138 Mon Mar  8 12:42:43 UTC 2021
example1: 139 Mon Mar  8 12:42:44 UTC 2021
example1: 140 Mon Mar  8 12:42:45 UTC 2021
example1: 141 Mon Mar  8 12:42:46 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-8vj2p \
        tailing-sidecar0 -n tailing-sidecar-system --tail 5
example2: 131 Mon Mar  8 12:42:43 UTC 2021
example2: 132 Mon Mar  8 12:42:44 UTC 2021
example2: 133 Mon Mar  8 12:42:45 UTC 2021
example2: 134 Mon Mar  8 12:42:46 UTC 2021
example2: 135 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-8vj2p \
        tailing-sidecar1 -n tailing-sidecar-system --tail 5
example0: 131 Mon Mar  8 12:42:43 UTC 2021
example0: 132 Mon Mar  8 12:42:44 UTC 2021
example0: 133 Mon Mar  8 12:42:45 UTC 2021
example0: 134 Mon Mar  8 12:42:46 UTC 2021
example0: 135 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-8vj2p \
        tailing-sidecar2 -n tailing-sidecar-system --tail 5
example1: 131 Mon Mar  8 12:42:43 UTC 2021
example1: 132 Mon Mar  8 12:42:44 UTC 2021
example1: 133 Mon Mar  8 12:42:45 UTC 2021
example1: 134 Mon Mar  8 12:42:46 UTC 2021
example1: 135 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-p7jjk \
        tailing-sidecar0 -n tailing-sidecar-system --tail 5
example2: 127 Mon Mar  8 12:42:43 UTC 2021
example2: 128 Mon Mar  8 12:42:44 UTC 2021
example2: 129 Mon Mar  8 12:42:45 UTC 2021
example2: 130 Mon Mar  8 12:42:46 UTC 2021
example2: 131 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-p7jjk \
        tailing-sidecar1 -n tailing-sidecar-system --tail 5
example0: 127 Mon Mar  8 12:42:43 UTC 2021
example0: 128 Mon Mar  8 12:42:44 UTC 2021
example0: 129 Mon Mar  8 12:42:45 UTC 2021
example0: 130 Mon Mar  8 12:42:46 UTC 2021
example0: 131 Mon Mar  8 12:42:47 UTC 2021
kubectl logs deployment-with-annotations-8c775686c-p7jjk \
        tailing-sidecar2 -n tailing-sidecar-system --tail 5
example1: 127 Mon Mar  8 12:42:43 UTC 2021
example1: 128 Mon Mar  8 12:42:44 UTC 2021
example1: 129 Mon Mar  8 12:42:45 UTC 2021
example1: 130 Mon Mar  8 12:42:46 UTC 2021
example1: 131 Mon Mar  8 12:42:47 UTC 2021
```

