### PR TITLE
makefile: add build-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,11 @@ mdl:
 yamllint:
 	yamllint -c .yamllint.yaml \
 		operator/examples/
+
+build-push-deploy: build-push-sidecar build-push-deploy-operator
+
+build-push-sidecar:
+	$(MAKE) -C sidecar all
+
+build-push-deploy-operator:
+	$(MAKE) -C operator all


### PR DESCRIPTION
Add `build-all` so one command in vagrant will be enough to deploy both sidecar and operator