### PR TITLE
Add operator.labels to all resources created by helm chart

### DIFF
--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -89,12 +89,16 @@ webhooks:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-service-account
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-leader-election-role
   namespace: {{ .Release.Namespace }}
 rules:
@@ -129,6 +133,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   creationTimestamp: null
   name: tailing-sidecar-manager-role
 rules:
@@ -156,6 +162,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-metrics-reader
 rules:
 - nonResourceURLs:
@@ -166,6 +174,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-proxy-role
 rules:
 - apiGroups:
@@ -184,6 +194,8 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
 roleRef:
@@ -198,6 +210,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -211,6 +225,8 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -239,6 +255,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-webhook-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -306,6 +324,8 @@ spec:
 apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-serving-cert
   namespace: {{ .Release.Namespace }}
 spec:
@@ -320,6 +340,8 @@ spec:
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
   name: tailing-sidecar-selfsigned-issuer
   namespace: {{ .Release.Namespace }}
 spec:


### PR DESCRIPTION
Before only Deployment and Service `tailing-sidecar-operator-metrics-service` had `operator.labels`
`helm create` command adds common labels to all resources so it will be good to follow this pattern.