### PR TITLE
ci: use Personal Access Token to login to Github container registry

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -22,18 +22,12 @@ jobs:
       - name: Build tailing sidecar image
         run: make build TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.CONTAINER_REGISTRY_APP_ID }}
-          private_key: ${{ secrets.CONTAINER_REGISTRY_PRIVATE_KEY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: USERNAME
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.CR_PAT }}
       - name: Push tailing sidecar image
         run: make push TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar
@@ -55,18 +49,12 @@ jobs:
       - name: Build tailing sidecar operator image
         run: make docker-build IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.CONTAINER_REGISTRY_APP_ID }}
-          private_key: ${{ secrets.CONTAINER_REGISTRY_PRIVATE_KEY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: USERNAME
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.CR_PAT }}
       - name: Push tailing sidecar operator image
         run: make docker-push IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -22,18 +22,12 @@ jobs:
       - name: Build tailing sidecar image
         run: make build TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.CONTAINER_REGISTRY_APP_ID }}
-          private_key: ${{ secrets.CONTAINER_REGISTRY_PRIVATE_KEY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: USERNAME
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.CR_PAT }}
       - name: Push tailing sidecar image
         run: make push TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar
@@ -55,18 +49,12 @@ jobs:
       - name: Build tailing sidecar operator image
         run: make docker-build IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v1
-        with:
-          app_id: ${{ secrets.CONTAINER_REGISTRY_APP_ID }}
-          private_key: ${{ secrets.CONTAINER_REGISTRY_PRIVATE_KEY }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: USERNAME
-          password: ${{ steps.generate_token.outputs.token }}
+          password: ${{ secrets.CR_PAT }}
       - name: Push tailing sidecar operator image
         run: make docker-push IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator


### PR DESCRIPTION
- Authentication to Github container registry requires personal access token, see: https://docs.github.com/en/packages/guides/configuring-docker-for-use-with-github-packages#authenticating-to-github-packages
-  Github container registry can’t accept App tokens, see [this](https://github.community/t/how-to-use-installation-access-token-in-ghcr-io-authorization/130666) discussion