### PR TITLE
chart: Make cert-manager optional

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -128,9 +128,6 @@ jobs:
             --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
       - name: Add Helm
         uses: WyriHaximus/github-action-helm3@v2.1.3
-      - name: Deploy cert-manager
-        working-directory: ./operator
-        run: make deploy-cert-manager
       - name: Build and push tailing sidecar image
         working-directory: ./sidecar
         run: make TAG=registry.localhost:5000/sumologic/tailing-sidecar:test
@@ -146,7 +143,55 @@ jobs:
       - name: Wait for operator to be ready
         run: |
           kubectl wait --for=condition=available --timeout 10s deploy -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
-          kubectl wait --for=condition=ready --timeout 10s pod -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
+          kubectl wait --for=condition=ready     --timeout 10s pod    -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
+      - name: Deploy examples
+        working-directory: ./operator
+        run: make deploy-examples
+      - name: Wait for logs to be generated
+        run: sleep 5
+      - name: Check Pods
+        run: kubectl get pods -n tailing-sidecar-system
+      - name: Check logs
+        working-directory: ./operator
+        run: make test-examples
+
+  deploy-helm-chart-with-cert-manager:
+    name: Deploy helm chart with cert-manager
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: imranismail/setup-kustomize@v1
+      - uses: AbsaOSS/k3d-action@v1.3.1
+        id: single-cluster
+        name: Create single k3d Cluster with Registry
+        with:
+          cluster-name: "test-cluster"
+          use-default-registry: true
+          args: >-
+            --agents 1
+            --no-lb
+            --k3s-server-arg "--no-deploy=traefik,servicelb,metrics-server"
+      - name: Add Helm
+        uses: WyriHaximus/github-action-helm3@v2.1.3
+      - name: Deploy cert-manager
+        working-directory: ./operator
+        run: make deploy-cert-manager
+      - name: Build and push tailing sidecar image
+        working-directory: ./sidecar
+        run: make TAG=registry.localhost:5000/sumologic/tailing-sidecar:test
+      - name: Build tailing sidecar operator
+        working-directory: ./operator
+        run: make docker-build IMG="registry.localhost:5000/sumologic/tailing-sidecar-operator:test"
+      - name: Push tailing sidecar operator
+        working-directory: ./operator
+        run: make docker-push IMG="registry.localhost:5000/sumologic/tailing-sidecar-operator:test"
+      - name: Deploy Helm chart
+        working-directory: ./helm
+        run: helm upgrade --install test-release ./tailing-sidecar-operator -f tests/values.withCertManager.yaml -n tailing-sidecar-system --create-namespace
+      - name: Wait for operator to be ready
+        run: |
+          kubectl wait --for=condition=available --timeout 10s deploy -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
+          kubectl wait --for=condition=ready     --timeout 10s pod    -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
       - name: Deploy examples
         working-directory: ./operator
         run: make deploy-examples

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -144,7 +144,9 @@ jobs:
         working-directory: ./helm
         run: helm upgrade --install test-release ./tailing-sidecar-operator -f tests/values.yaml -n tailing-sidecar-system --create-namespace
       - name: Wait for operator to be ready
-        run: kubectl wait --for=condition=ready --timeout 60s pod -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
+        run: |
+          kubectl wait --for=condition=available --timeout 10s deploy -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
+          kubectl wait --for=condition=ready --timeout 10s pod -l app.kubernetes.io/name=tailing-sidecar-operator -n tailing-sidecar-system
       - name: Deploy examples
         working-directory: ./operator
         run: make deploy-examples

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -110,8 +110,8 @@ jobs:
         working-directory: ./operator
         run: make test-examples
 
-  deploy-helm-chart:
-    name: Deploy helm chart for tailing sidecar operator
+  test-helm-chart:
+    name: Test Helm chart
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -155,8 +155,8 @@ jobs:
         working-directory: ./operator
         run: make test-examples
 
-  deploy-helm-chart-with-cert-manager:
-    name: Deploy helm chart with cert-manager
+  test-helm-chart-with-cert-manager:
+    name: Test Helm chart with cert-manager
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/helm/tailing-sidecar-operator/README.md
+++ b/helm/tailing-sidecar-operator/README.md
@@ -39,4 +39,4 @@ are created using Helm's functions `genCA` and `genSignedCert`.
 The generated certificate is valid for 365 days after issuing, i.e. after chart installation.
 
 If you have [cert-manager](https://cert-manager.io/) installed in your cluster,
-you can make the chart use it for certificate management by setting the property `useCertManager` to `true`.
+you can make the chart use it for certificate management by setting the property `certManager.enabled` to `true`.

--- a/helm/tailing-sidecar-operator/README.md
+++ b/helm/tailing-sidecar-operator/README.md
@@ -10,12 +10,8 @@ to pods in your cluster by adding annotations on the pods.
 
 Before installing this chart, ensure the following prerequisites are satisfied in your cluster:
 
-- [cert-manager](https://cert-manager.io/docs/installation/) is installed
 - [admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#prerequisites)
   are enabled
-
-Unfortunately, due to a limitation of `cert-manager` chart, it cannot be used as a dependency and needs to be installed separately.
-See issue [jetstack/cert-manager#3062](https://github.com/jetstack/cert-manager/issues/3062) for details.
 
 ## Installing
 
@@ -35,3 +31,12 @@ helm uninstall tailing-sidecar-operator
 ## Configuration
 
 See [values.yaml](./values.yaml) file for the available configuration options.
+
+### Using `cert-manager` to manage operator's certificates
+
+By default, TLS certificates for the Tailing Sidecar Operator's API webhook
+are created using Helm's functions `genCA` and `genSignedCert`.
+The generated certificate is valid for 365 days after issuing, i.e. after chart installation.
+
+If you have [cert-manager](https://cert-manager.io/) installed in your cluster,
+you can make the chart use it for certificate management by setting the property `useCertManager` to `true`.

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
@@ -1,0 +1,54 @@
+{{- define "operator.webhookWithCertManager" }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/tailing-sidecar-serving-cert
+  name: tailing-sidecar-mutating-webhook-configuration
+  namespace: {{ .Release.Namespace }}
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: {{ include "operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /add-tailing-sidecars-v1-pod
+  failurePolicy:  Ignore
+  name: tailing-sidecar.sumologic.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  name: tailing-sidecar-serving-cert
+  namespace: {{ .Release.Namespace }}
+spec:
+  dnsNames:
+  - {{ include "operator.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "operator.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: tailing-sidecar-selfsigned-issuer
+  secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  name: tailing-sidecar-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
@@ -1,0 +1,44 @@
+{{- define "operator.webhook" -}}
+{{- $altNames := list ( printf "%s.%s" (include "operator.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "operator.fullname" .) .Release.Namespace ) -}}
+{{- $ca := genCA "tailing-sidecar-operator-ca" 365 -}}
+{{- $cert := genSignedCert ( include "operator.fullname" . ) nil $altNames 365 $ca -}}
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: tailing-sidecar-mutating-webhook-configuration
+  namespace: {{ .Release.Namespace }}
+webhooks:
+- clientConfig:
+    caBundle: {{ $ca.Cert | b64enc }}
+    service:
+      name: {{ include "operator.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /add-tailing-sidecars-v1-pod
+  failurePolicy:  Ignore
+  name: tailing-sidecar.sumologic.com
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+  labels:
+    {{- include "operator.labels" . | nindent 4 }}
+  name: webhook-server-cert
+  namespace: {{ .Release.Namespace }}
+data:
+  tls.crt: {{ $cert.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+{{- end }}

--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -58,33 +58,11 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/tailing-sidecar-serving-cert
-  creationTimestamp: null
-  name: tailing-sidecar-mutating-webhook-configuration
-  namespace: {{ .Release.Namespace }}
-webhooks:
-- clientConfig:
-    caBundle: Cg==
-    service:
-      name: tailing-sidecar-webhook-service
-      namespace: {{ .Release.Namespace }}
-      path: /add-tailing-sidecars-v1-pod
-  failurePolicy:  Ignore
-  name: tailing-sidecar.sumologic.com
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pods
+{{- if .Values.useCertManager -}}
+{{- include "operator.webhookWithCertManager" . }}
+{{- else }}
+{{- include "operator.webhook" . }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -257,7 +235,7 @@ kind: Service
 metadata:
   labels:
     {{- include "operator.labels" . | nindent 4 }}
-  name: tailing-sidecar-webhook-service
+  name: {{ include "operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -271,7 +249,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "operator.labels" . | nindent 4 }}
-  name: tailing-sidecar-operator
+  name: {{ include "operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
@@ -320,29 +298,3 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
-metadata:
-  labels:
-    {{- include "operator.labels" . | nindent 4 }}
-  name: tailing-sidecar-serving-cert
-  namespace: {{ .Release.Namespace }}
-spec:
-  dnsNames:
-  - tailing-sidecar-webhook-service.{{ .Release.Namespace }}.svc
-  - tailing-sidecar-webhook-service.{{ .Release.Namespace }}.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: tailing-sidecar-selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1alpha2
-kind: Issuer
-metadata:
-  labels:
-    {{- include "operator.labels" . | nindent 4 }}
-  name: tailing-sidecar-selfsigned-issuer
-  namespace: {{ .Release.Namespace }}
-spec:
-  selfSigned: {}

--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -58,7 +58,7 @@ spec:
     served: true
     storage: true
 ---
-{{- if .Values.useCertManager -}}
+{{- if .Values.certManager.enabled -}}
 {{- include "operator.webhookWithCertManager" . }}
 {{- else }}
 {{- include "operator.webhook" . }}

--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -18,3 +18,6 @@ sidecar:
   image:
     repository: public.ecr.aws/sumologic/tailing-sidecar
     tag: 0.0.0
+
+
+useCertManager: false

--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -19,5 +19,5 @@ sidecar:
     repository: public.ecr.aws/sumologic/tailing-sidecar
     tag: 0.0.0
 
-
-useCertManager: false
+certManager:
+  enabled: false

--- a/helm/tests/values.withCertManager.yaml
+++ b/helm/tests/values.withCertManager.yaml
@@ -8,4 +8,5 @@ sidecar:
     repository: registry.localhost:5000/sumologic/tailing-sidecar
     tag: test
 
-useCertManager: true
+certManager:
+  enabled: true

--- a/helm/tests/values.withCertManager.yaml
+++ b/helm/tests/values.withCertManager.yaml
@@ -1,0 +1,11 @@
+operator:
+  image:
+    repository: registry.localhost:5000/sumologic/tailing-sidecar-operator
+    tag: test
+
+sidecar:
+  image:
+    repository: registry.localhost:5000/sumologic/tailing-sidecar
+    tag: test
+
+useCertManager: true


### PR DESCRIPTION
Added chart property `useCertManager` which is `false` by default, but when changed to `true` it makes it possible to use `cert-manager` if you have it in your cluster.

@sumo-drosiek mentioned that the Telegraf chart's property to use `cert-manager` is called [certManager.enable](https://github.com/influxdata/helm-charts/blob/046d1691553807922ee01fd525f3b1c4efdf0e96/charts/telegraf-operator/values.yaml#L21) and there's value in keeping things consistent, but I don't really like the name (it should be `enabled` and not `enable` anyway). Please give your opinions on the property name.