### PR TITLE
Revert "ci: add --always to git describe command to set version when there is no tag"

### DIFF
--- a/ci/push-helm-chart.sh
+++ b/ci/push-helm-chart.sh
@@ -5,7 +5,7 @@ readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
 source "${ROOT_DIR}"/ci/_build_functions.sh
 
 fetch_current_branch
-VERSION="$(git describe --tags --abbrev=40 --always)"
+VERSION="$(git describe --tags --abbrev=40)"
 readonly VERSION="${VERSION#v}"
 
 pushd "${ROOT_DIR}" || exit 1


### PR DESCRIPTION
Reverts SumoLogic/tailing-sidecar#91

helm package requires semantic versioning
```
export VERSION="$(git describe --tags --abbrev=40 --always)"
%  helm package helm/tailing-sidecar-operator --dependency-update --version="${VERSION}" --app-version="${VERSION}" --destination test
Error: Invalid Semantic Version
```