### PR TITLE
docs: add commands for Helm chart installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,29 @@
 
 ![Project Status](https://img.shields.io/badge/status-alpha-important?style=for-the-badge)
 
+## TL;DR
+
+```sh
+helm repo add tailing-sidecar https://sumologic.github.io/tailing-sidecar
+helm repo update
+```
+
+```sh
+helm upgrade --install tailing-sidecar tailing-sidecar/tailing-sidecar-operator \
+  -n tailing-sidecar-system \
+  --create-namespace
+```
+
+Add `tailing-sidecar` annotation to Pod:
+
+```yaml
+metadata:
+  annotations:
+    tailing-sidecar: <sidecar-name-0>:<volume-name-0>:<path-to-tail-0>;<sidecar-name-1>:<volume-name-1>:<path-to-tail-1>
+```
+
+## Tailing Sidecar
+
 **tailing sidecar** is a [streaming sidecar container](https://kubernetes.io/docs/concepts/cluster-administration/logging/#streaming-sidecar-container),
 the cluster-level logging agent for Kubernetes.
 

--- a/helm/tailing-sidecar-operator/README.md
+++ b/helm/tailing-sidecar-operator/README.md
@@ -15,11 +15,19 @@ Before installing this chart, ensure the following prerequisites are satisfied i
 
 ## Installing
 
-Having satisfied the [Prerequisites](#prerequisites), run the following to install the chart:
+Having satisfied the [Prerequisites](#prerequisites), run the following to add Helm repository:
 
 ```sh
-helm repo add TBD TBD
-helm install tailing-sidecar-operator TBD
+helm repo add tailing-sidecar https://sumologic.github.io/tailing-sidecar
+helm repo update
+```
+
+and install Helm chart:
+
+```sh
+helm upgrade --install tailing-sidecar tailing-sidecar/tailing-sidecar-operator \
+  -n tailing-sidecar-system \
+  --create-namespace
 ```
 
 ## Uninstalling


### PR DESCRIPTION
docs: add commands for Helm chart installation
docs: add TL;DR section in main README.md

Release v0.1.0 has wrong images set so for this release following command needs to be used:
```
helm upgrade --install tailing-sidecar tailing-sidecar/tailing-sidecar-operator -n tailing-sidecar-system --create-namespace \
--set operator.image.tag=0.1.0 \
--set sidecar.image.tag=0.1.0 \
--set operator.image.repository=ghcr.io/sumologic/tailing-sidecar-operator
--set operator.image.repository=ghcr.io/sumologic/tailing-sidecar
```