### PR TITLE
chart: fix sidecar image repository

### DIFF
--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -16,7 +16,7 @@ operator:
 
 sidecar:
   image:
-    repository: ghcr.io/sumologic/tailing-sidecar-operator
+    repository: ghcr.io/sumologic/tailing-sidecar
     tag: 0.1.0
 
 certManager:


### PR DESCRIPTION
Proper repository for sidecar image is `ghcr.io/sumologic/tailing-sidecar`
https://github.com/orgs/SumoLogic/packages/container/package/tailing-sidecar