### PR TITLE
refactor: chart: Rename defined templates' namespace

### DIFF
--- a/helm/tailing-sidecar-operator/templates/_helpers.tpl
+++ b/helm/tailing-sidecar-operator/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "operator.name" -}}
+{{- define "tailing-sidecar-operator.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "operator.fullname" -}}
+{{- define "tailing-sidecar-operator.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "operator.chart" -}}
+{{- define "tailing-sidecar-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "operator.labels" -}}
-helm.sh/chart: {{ include "operator.chart" . }}
-{{ include "operator.selectorLabels" . }}
+{{- define "tailing-sidecar-operator.labels" -}}
+helm.sh/chart: {{ include "tailing-sidecar-operator.chart" . }}
+{{ include "tailing-sidecar-operator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,7 +45,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "operator.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "operator.name" . }}
+{{- define "tailing-sidecar-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "tailing-sidecar-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
@@ -1,4 +1,4 @@
-{{- define "operator.webhookWithCertManager" }}
+{{- define "tailing-sidecar-operator.webhookWithCertManager" }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -10,7 +10,7 @@ webhooks:
 - clientConfig:
     caBundle: Cg==
     service:
-      name: {{ include "operator.fullname" . }}
+      name: {{ include "tailing-sidecar-operator.fullname" . }}
       namespace: {{ .Release.Namespace }}
       path: /add-tailing-sidecars-v1-pod
   failurePolicy:  Ignore
@@ -30,13 +30,13 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-serving-cert
   namespace: {{ .Release.Namespace }}
 spec:
   dnsNames:
-  - {{ include "operator.fullname" . }}.{{ .Release.Namespace }}.svc
-  - {{ include "operator.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  - {{ include "tailing-sidecar-operator.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "tailing-sidecar-operator.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: tailing-sidecar-selfsigned-issuer
@@ -46,7 +46,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-selfsigned-issuer
   namespace: {{ .Release.Namespace }}
 spec:

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
@@ -1,7 +1,7 @@
-{{- define "operator.webhook" -}}
-{{- $altNames := list ( printf "%s.%s" (include "operator.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "operator.fullname" .) .Release.Namespace ) -}}
+{{- define "tailing-sidecar-operator.webhook" -}}
+{{- $altNames := list ( printf "%s.%s" (include "tailing-sidecar-operator.fullname" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "tailing-sidecar-operator.fullname" .) .Release.Namespace ) -}}
 {{- $ca := genCA "tailing-sidecar-operator-ca" 365 -}}
-{{- $cert := genSignedCert ( include "operator.fullname" . ) nil $altNames 365 $ca -}}
+{{- $cert := genSignedCert ( include "tailing-sidecar-operator.fullname" . ) nil $altNames 365 $ca -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -11,7 +11,7 @@ webhooks:
 - clientConfig:
     caBundle: {{ $ca.Cert | b64enc }}
     service:
-      name: {{ include "operator.fullname" . }}
+      name: {{ include "tailing-sidecar-operator.fullname" . }}
       namespace: {{ .Release.Namespace }}
       path: /add-tailing-sidecars-v1-pod
   failurePolicy:  Ignore
@@ -35,7 +35,7 @@ metadata:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-delete-policy": "before-hook-creation"
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: webhook-server-cert
   namespace: {{ .Release.Namespace }}
 data:

--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -59,16 +59,16 @@ spec:
     storage: true
 ---
 {{- if .Values.certManager.enabled -}}
-{{- include "operator.webhookWithCertManager" . }}
+{{- include "tailing-sidecar-operator.webhookWithCertManager" . }}
 {{- else }}
-{{- include "operator.webhook" . }}
+{{- include "tailing-sidecar-operator.webhook" . }}
 {{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-service-account
   namespace: {{ .Release.Namespace }}
 ---
@@ -76,7 +76,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-leader-election-role
   namespace: {{ .Release.Namespace }}
 rules:
@@ -112,7 +112,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   creationTimestamp: null
   name: tailing-sidecar-manager-role
 rules:
@@ -141,7 +141,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-metrics-reader
 rules:
 - nonResourceURLs:
@@ -153,7 +153,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-proxy-role
 rules:
 - apiGroups:
@@ -173,7 +173,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-leader-election-rolebinding
   namespace: {{ .Release.Namespace }}
 roleRef:
@@ -189,7 +189,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -204,7 +204,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -219,7 +219,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
   name: tailing-sidecar-operator-metrics-service
   namespace: {{ .Release.Namespace }}
 spec:
@@ -228,38 +228,38 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    {{- include "operator.selectorLabels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.selectorLabels" . | nindent 4 }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
-  name: {{ include "operator.fullname" . }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
+  name: {{ include "tailing-sidecar-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - port: 443
     targetPort: 9443
   selector:
-    {{- include "operator.selectorLabels" . | nindent 4 }}
+    {{- include "tailing-sidecar-operator.selectorLabels" . | nindent 4 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    {{- include "operator.labels" . | nindent 4 }}
-  name: {{ include "operator.fullname" . }}
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
+  name: {{ include "tailing-sidecar-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "operator.selectorLabels" . | nindent 6 }}
+      {{- include "tailing-sidecar-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "operator.selectorLabels" . | nindent 8 }}
+        {{- include "tailing-sidecar-operator.selectorLabels" . | nindent 8 }}
     spec:
       containers:
       - args:


### PR DESCRIPTION
According to [Helm Best Practices](https://helm.sh/docs/chart_best_practices/templates/#names-of-defined-templates),
"all defined template names should be namespaced"
because they are globally accessible.