### PR TITLE
Set default tag for container images to .Chart.AppVersion

### DIFF
--- a/dev/releasing.md
+++ b/dev/releasing.md
@@ -1,9 +1,8 @@
 # Tailing Sidecar Release Instruction
 
-1. Prepare Release pull request with Helm Chart version change in [Chart.yaml](../helm/tailing-sidecar-operator/Chart.yaml)
-   and version change for container images in [values.yaml](../helm/tailing-sidecar-operator/values.yaml)
+1. Prepare Release pull request with Helm Chart version change in [Chart.yaml](../helm/tailing-sidecar-operator/Chart.yaml).
 
-1. Create the release tag for commit with Helm Chart version change and version change for container images, e.g.
+1. Create the release tag for commit with Helm Chart version change, e.g.
 
    ```bash
    git tag -a v0.1.0 -m "Release v0.1.0"

--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -275,10 +275,10 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --tailing-sidecar-image={{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag }}
+        - --tailing-sidecar-image={{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}
         command:
         - /manager
-        image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
+        image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         name: manager
         ports:

--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -5,7 +5,8 @@ operator:
   image:
     pullPolicy: IfNotPresent
     repository: ghcr.io/sumologic/tailing-sidecar-operator
-    tag: 0.3.0
+    # Overrides the image tag whose default is the Helm Chart appVersion.
+    tag: ""
   resources:
     limits:
       cpu: 100m
@@ -17,7 +18,8 @@ operator:
 sidecar:
   image:
     repository: ghcr.io/sumologic/tailing-sidecar
-    tag: 0.3.0
+    # Overrides the image tag whose default is the Helm Chart appVersion.
+    tag: ""
 
 # Configuration for MutatingWebhook which is used by tailing sidecar operator
 # for details please see Kubernetes API Reference Docs


### PR DESCRIPTION
There will be no need to remember about changing image tags when new release is created.

Fixes #97