### PR TITLE
Change prefix for tailing sidecar volume name to volume-sidecar-

### DIFF
--- a/operator/handler/handler.go
+++ b/operator/handler/handler.go
@@ -43,8 +43,8 @@ const (
 	sidecarContainerPrefix = "tailing-sidecar-"
 
 	hostPathDirPath      = "/var/log/tailing-sidecar-fluentbit/%s/%s"
-	hostPathVolumeName   = "volume-sidecar%d"
-	hostPathVolumePrefix = "volume-sidecar"
+	hostPathVolumeName   = "volume-sidecar-%d"
+	hostPathVolumePrefix = "volume-sidecar-"
 	hostPathMountPath    = "/tailing-sidecar/var"
 )
 

--- a/operator/handler/handler_test.go
+++ b/operator/handler/handler_test.go
@@ -593,7 +593,7 @@ var _ = Describe("handler", func() {
 										"mountPath": "/varconfig/log"
 									  },
 									  {
-										"name": "volume-sidecar0",
+										"name": "volume-sidecar-0",
 										"mountPath": "/tailing-sidecar/var"
 									  }
 									]
@@ -609,7 +609,7 @@ var _ = Describe("handler", func() {
 								  "emptyDir": {}
 								},
 								{
-									"name": "volume-sidecar0",
+									"name": "volume-sidecar-0",
 									"hostPath": {
 									  "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-0",
 									  "type": "DirectoryOrCreate"
@@ -1197,7 +1197,7 @@ var _ = Describe("handler", func() {
 									"volumeMounts": [
 									  {
 										"mountPath": "/tailing-sidecar/var",
-										"name": "volume-sidecar0"
+										"name": "volume-sidecar-0"
 									  },
 									  {
 										"name": "varlogconfig",
@@ -1216,7 +1216,7 @@ var _ = Describe("handler", func() {
 								  "emptyDir": {}
 								},
 								{
-								  "name": "volume-sidecar0",
+								  "name": "volume-sidecar-0",
 								  "hostPath":
 								  {
 									"path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container",
@@ -1571,7 +1571,7 @@ var _ = Describe("handler", func() {
 									"volumeMounts": [
 									  {
 										"mountPath": "/tailing-sidecar/var",
-										"name": "volume-sidecar0"
+										"name": "volume-sidecar-0"
 									  },
 									  {
 										"name": "varlogconfig",
@@ -1590,7 +1590,7 @@ var _ = Describe("handler", func() {
 								  "emptyDir": {}
 								},
 								{
-								  "name": "volume-sidecar0",
+								  "name": "volume-sidecar-0",
 								  "hostPath":
 								  {
 									"path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-0",

--- a/operator/handler/testdata/patch_update_1_tailing_sidecar.json
+++ b/operator/handler/testdata/patch_update_1_tailing_sidecar.json
@@ -23,7 +23,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar1"
+                    "name": "volume-sidecar-1"
                 }
             ]
         }
@@ -36,7 +36,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-1",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar1"
+            "name": "volume-sidecar-1"
         }
     }
 ]

--- a/operator/handler/testdata/patch_with_2_tailing_sidecars.json
+++ b/operator/handler/testdata/patch_with_2_tailing_sidecars.json
@@ -23,7 +23,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar0"
+                    "name": "volume-sidecar-0"
                 }
             ]
         }
@@ -52,7 +52,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar1"
+                    "name": "volume-sidecar-1"
                 }
             ]
         }
@@ -65,7 +65,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-0",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar0"
+            "name": "volume-sidecar-0"
         }
     },
     {
@@ -76,7 +76,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-1",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar1"
+            "name": "volume-sidecar-1"
         }
     }
 ]

--- a/operator/handler/testdata/patch_with_3_named_tailing_sidecars.json
+++ b/operator/handler/testdata/patch_with_3_named_tailing_sidecars.json
@@ -23,7 +23,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar0"
+                    "name": "volume-sidecar-0"
                 }
             ]
         }
@@ -52,7 +52,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar1"
+                    "name": "volume-sidecar-1"
                 }
             ]
         }
@@ -81,7 +81,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar2"
+                    "name": "volume-sidecar-2"
                 }
             ]
         }
@@ -94,7 +94,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container2",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar0"
+            "name": "volume-sidecar-0"
         }
     },
     {
@@ -105,7 +105,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container0",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar1"
+            "name": "volume-sidecar-1"
         }
     },
     {
@@ -116,7 +116,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container1",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar2"
+            "name": "volume-sidecar-2"
         }
     }
 ]

--- a/operator/handler/testdata/patch_with_3_tailing_sidecars.json
+++ b/operator/handler/testdata/patch_with_3_tailing_sidecars.json
@@ -7,7 +7,7 @@
                                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-0",
                                 "type": "DirectoryOrCreate"
                         },
-                        "name": "volume-sidecar0"
+                        "name": "volume-sidecar-0"
                 }
         },
         {
@@ -18,7 +18,7 @@
                                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-1",
                                 "type": "DirectoryOrCreate"
                         },
-                        "name": "volume-sidecar1"
+                        "name": "volume-sidecar-1"
                 }
         },
         {
@@ -29,7 +29,7 @@
                                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-2",
                                 "type": "DirectoryOrCreate"
                         },
-                        "name": "volume-sidecar2"
+                        "name": "volume-sidecar-2"
                 }
         },
         {
@@ -56,7 +56,7 @@
                                 },
                                 {
                                         "mountPath": "/tailing-sidecar/var",
-                                        "name": "volume-sidecar0"
+                                        "name": "volume-sidecar-0"
                                 }
                         ]
                 }
@@ -85,7 +85,7 @@
                                 },
                                 {
                                         "mountPath": "/tailing-sidecar/var",
-                                        "name": "volume-sidecar1"
+                                        "name": "volume-sidecar-1"
                                 }
                         ]
                 }
@@ -114,7 +114,7 @@
                                 },
                                 {
                                         "mountPath": "/tailing-sidecar/var",
-                                        "name": "volume-sidecar2"
+                                        "name": "volume-sidecar-2"
                                 }
                         ]
                 }

--- a/operator/handler/testdata/patch_with_4_named_not_named_tailing_sidecars.json
+++ b/operator/handler/testdata/patch_with_4_named_not_named_tailing_sidecars.json
@@ -7,7 +7,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container2",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar0"
+            "name": "volume-sidecar-0"
         }
     },
     {
@@ -18,7 +18,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-1",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar1"
+            "name": "volume-sidecar-1"
         }
     },
     {
@@ -29,7 +29,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/test-container0",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar2"
+            "name": "volume-sidecar-2"
         }
     },
     {
@@ -40,7 +40,7 @@
                 "path": "/var/log/tailing-sidecar-fluentbit/tailing-sidecar-system/pod-with-annotations/tailing-sidecar-3",
                 "type": "DirectoryOrCreate"
             },
-            "name": "volume-sidecar3"
+            "name": "volume-sidecar-3"
         }
     },
     {
@@ -67,7 +67,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar0"
+                    "name": "volume-sidecar-0"
                 }
             ]
         }
@@ -96,7 +96,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar1"
+                    "name": "volume-sidecar-1"
                 }
             ]
         }
@@ -125,7 +125,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar2"
+                    "name": "volume-sidecar-2"
                 }
             ]
         }
@@ -154,7 +154,7 @@
                 },
                 {
                     "mountPath": "/tailing-sidecar/var",
-                    "name": "volume-sidecar3"
+                    "name": "volume-sidecar-3"
                 }
             ]
         }

--- a/sidecar/README.md
+++ b/sidecar/README.md
@@ -75,7 +75,7 @@ spec:
     volumeMounts:
     - name: varlog
       mountPath: /var/log
-    - name: volume-sidecar1
+    - name: volume-sidecar-1
       mountPath: /tailing-sidecar/var
   - name: sidecar2
     image: ghcr.io/sumologic/tailing-sidecar:latest
@@ -87,16 +87,16 @@ spec:
     volumeMounts:
     - name: varlog
       mountPath: /var/log
-    - name: volume-sidecar2
+    - name: volume-sidecar-2
       mountPath: /tailing-sidecar/var
   volumes:
   - name: varlog
     emptyDir: {}
-  - name: volume-sidecar1
+  - name: volume-sidecar-1
     hostPath:
       path: /var/log/sidecar1
       type: DirectoryOrCreate
-  - name: volume-sidecar2
+  - name: volume-sidecar-2
     hostPath:
       path: /var/log/sidecar2
       type: DirectoryOrCreate

--- a/sidecar/examples/pod_with_tailing_sidecars.yaml
+++ b/sidecar/examples/pod_with_tailing_sidecars.yaml
@@ -29,7 +29,7 @@ spec:
     volumeMounts:
     - name: varlog
       mountPath: /var/log
-    - name: volume-sidecar1
+    - name: volume-sidecar-1
       mountPath: /tailing-sidecar/var
   - name: sidecar2
     image: ghcr.io/sumologic/tailing-sidecar:latest
@@ -39,16 +39,16 @@ spec:
     volumeMounts:
     - name: varlog
       mountPath: /var/log
-    - name: volume-sidecar2
+    - name: volume-sidecar-2
       mountPath: /tailing-sidecar/var
   volumes:
   - name: varlog
     emptyDir: {}
-  - name: volume-sidecar1
+  - name: volume-sidecar-1
     hostPath:
       path: /var/log/sidecar1
       type: DirectoryOrCreate
-  - name: volume-sidecar2
+  - name: volume-sidecar-2
     hostPath:
       path: /var/log/sidecar2
       type: DirectoryOrCreate


### PR DESCRIPTION
Change prefix for tailing sidecar volume name to `volume-sidecar-` to keep the same style as in naming sidecar container