### PR TITLE
Changes in ci jobs running for pull requests

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -47,8 +47,8 @@ jobs:
         working-directory: ./operator
         run: make manager
 
-  create-resources-with-sidecars:
-    name: Create resources with sidecars
+  test-without-helm:
+    name: Test resources created without Helm chart
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -47,15 +47,6 @@ jobs:
         working-directory: ./operator
         run: make manager
 
-  build-operator-image:
-    name: Build tailing sidecar operator image
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build tailing sidecar operator image
-        working-directory: ./operator
-        run: make docker-build
-
   create-resources-with-sidecars:
     name: Create resources with sidecars
     runs-on: ubuntu-20.04

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: [ '1.15', '1.14' ]
+        go: [ '1.16', '1.15', '1.14' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup go

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -28,15 +28,6 @@ jobs:
       - name: yamllint
         run: make yamllint
 
-  build-sidecar-image:
-    name: Build tailing sidecar image
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build tailing-sidecar image
-        working-directory: ./sidecar
-        run: make build
-
   build-operator:
     name: Build tailing sidecar operator
     runs-on: ubuntu-20.04


### PR DESCRIPTION
- remove redundant job to build sidecar image, `build` target is included in `make all` for sidecar and it is run  [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L87), [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L133), [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L181)
- remove redundant job to build tailing sidecar operator image , `docker-build` target is included in `make all` for operator and it is run [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L103), [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L136), [here](https://github.com/SumoLogic/tailing-sidecar/blob/5914e56cf04792193ef2dbe9b38f609d051c31eb/.github/workflows/pull_requests.yml#L184)
- rename job to test resources without Helm chart
- add go 1.16 to tests matrix