### PR TITLE
operator: add explicit non blocking handling of Pod deletion

### DIFF
--- a/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
@@ -28,6 +28,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - pods
 ---

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
@@ -29,6 +29,7 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - pods
 ---

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -22,5 +22,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
+    - DELETE
     resources:
     - pods


### PR DESCRIPTION
Trying to change volumeMount type from string to
VolumeMount from k8s.io/api/core/v1 observed that
when Pod is modified through kubectl apply --force deletion hangs

Related to #55 and #119