### PR TITLE
Add tests for update of resources modified by operator

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -95,6 +95,14 @@ jobs:
       - name: Check logs
         working-directory: ./operator
         run: make test-examples
+      - name: Deploy examples update
+        working-directory: ./operator
+        run: make deploy-examples-update
+      - name: Wait for logs to be generated
+        run: sleep 5
+      - name: Check logs after update
+        working-directory: ./operator
+        run: make test-examples-update
 
   test-helm-chart:
     name: Test Helm chart
@@ -144,6 +152,14 @@ jobs:
       - name: Check logs
         working-directory: ./operator
         run: make test-examples
+      - name: Deploy examples update
+        working-directory: ./operator
+        run: make deploy-examples-update
+      - name: Wait for logs to be generated
+        run: sleep 5
+      - name: Check logs after update
+        working-directory: ./operator
+        run: make test-examples-update
 
   test-helm-chart-with-cert-manager:
     name: Test Helm chart with cert-manager
@@ -196,3 +212,11 @@ jobs:
       - name: Check logs
         working-directory: ./operator
         run: make test-examples
+      - name: Deploy examples update
+        working-directory: ./operator
+        run: make deploy-examples-update
+      - name: Wait for logs to be generated
+        run: sleep 5
+      - name: Check logs after update
+        working-directory: ./operator
+        run: make test-examples-update

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -50,6 +50,7 @@ jobs:
   test-without-helm:
     name: Test resources created without Helm chart
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: imranismail/setup-kustomize@v1
@@ -98,6 +99,7 @@ jobs:
   test-helm-chart:
     name: Test Helm chart
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: imranismail/setup-kustomize@v1
@@ -146,6 +148,7 @@ jobs:
   test-helm-chart-with-cert-manager:
     name: Test Helm chart with cert-manager
     runs-on: ubuntu-20.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
       - uses: imranismail/setup-kustomize@v1

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -106,6 +106,10 @@ teardown-examples:
 test-examples:
 	tests/test.sh
 
+# Check if logs from resources created with make deploy-examples-update have proper content
+test-examples-update:
+	tests/test-update.sh
+
 # Check resources created with make deploy-examples
 check-examples:
 	kubectl get all -n tailing-sidecar-system
@@ -134,7 +138,11 @@ check-examples:
 # Check resources created with make deploy-examples-update
 check-examples-update:
 	kubectl get all -n tailing-sidecar-system
+	kubectl logs pod-with-annotations tailing-sidecar-0 -n tailing-sidecar-system --tail 5
 	kubectl logs pod-with-annotations named-sidecar -n tailing-sidecar-system --tail 5
+	kubectl logs pod-with-annotations tailing-sidecar-1 -n tailing-sidecar-system --tail 5
+	kubectl logs $(shell kubectl get pod -l app=deployment-with-annotations -n tailing-sidecar-system -o jsonpath="{.items[0].metadata.name}") \
+		tailing-sidecar-0 -n tailing-sidecar-system --tail 5
 
 # Deploy cert-manager
 deploy-cert-manager:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -78,10 +78,6 @@ deploy-examples:
 	kubectl apply -f examples/deployment_with_annotations.yaml
 	kubectl apply -f examples/daemonset_with_annotations.yaml
 	kubectl apply -f examples/pod_without_annotations.yaml
-	kubectl wait --for=condition=ready --timeout 60s pod -l app=pod-with-annotations -n tailing-sidecar-system
-	kubectl wait --for=condition=ready --timeout 60s pod -l app=deployment-with-annotations -n tailing-sidecar-system
-	kubectl wait --for=condition=ready --timeout 60s pod -l app=statefulset-with-annotations -n tailing-sidecar-system
-	kubectl wait --for=condition=ready --timeout 60s pod -l app=daemonset-with-annotations -n tailing-sidecar-system
 
 # Deploy examples update
 deploy-examples-update:
@@ -91,7 +87,6 @@ deploy-examples-update:
 deploy-example-with-crd:
 	kubectl apply -f config/samples/tailing-sidecar_v1_tailingsidecar.yaml -n tailing-sidecar-system
 	kubectl apply -f tests/pod_with_annotations_crd.yaml
-	kubectl wait --for=condition=ready --timeout 60s pod -l app=pod-with-annotations-crd -n tailing-sidecar-system
 
 # Remove resources created with make deploy-examples
 teardown-examples:

--- a/operator/tests/functions.sh
+++ b/operator/tests/functions.sh
@@ -10,7 +10,7 @@ function wait_for_pod() {
   do
     get="$(kubectl get pods -n $namespace $pod)"
     if [[ ! $get =~ $state ]]; then
-      echo "Waiting for pod $pod in $i interation"
+      echo "Waiting for pod $pod in $i iteration"
       sleep 1
     else
       echo "Found pod $pod"
@@ -25,8 +25,8 @@ function wait_for_all_pods_running() {
 
   for i in $(seq 0 $time)
   do
-    pods="$(kubectl get pods -n $namespace | tail -n +2 | wc -l)"
     running_pods="$(kubectl get pods -n $namespace | grep Running | wc -l)"
+    pods="$(kubectl get pods -n $namespace | tail -n +2 | wc -l)"
     if [[ $pods -eq $running_pods ]]; then
       echo "All Pods are in Running state"
       break

--- a/operator/tests/functions.sh
+++ b/operator/tests/functions.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+function wait_for_pod() {
+  local namespace="$1"
+  local pod="$2"
+  local time="$3"
+  local state="Running"
+
+  for i in $(seq 0 $time)
+  do
+    get="$(kubectl get pods -n $namespace $pod)"
+    if [[ ! $get =~ $state ]]; then
+      echo "Waiting for pod $pod in $i interation"
+      sleep 1
+    else
+      echo "Found pod $pod"
+      break
+    fi
+  done
+}
+
+function wait_for_all_pods_running() {
+  local namespace="$1"
+  local time="$2"
+
+  for i in $(seq 0 $time)
+  do
+    pods="$(kubectl get pods -n $namespace | tail -n +2 | wc -l)"
+    running_pods="$(kubectl get pods -n $namespace | grep Running | wc -l)"
+    if [[ $pods -eq $running_pods ]]; then
+      echo "All Pods are in Running state"
+      break
+    fi
+    echo "$(kubectl get pods -n $namespace)"
+    sleep 1
+  done
+}

--- a/operator/tests/test-update.sh
+++ b/operator/tests/test-update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Check Pod logs
+[[ $(kubectl logs pod-with-annotations tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs pod-with-annotations named-sidecar -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs pod-with-annotations tailing-sidecar-1 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+
+# Check Deployment logs
+readonly DEPLOYMENT_POD_NAME="$(kubectl get pod -l app=deployment-with-annotations -n tailing-sidecar-system -o jsonpath="{.items[0].metadata.name}")"
+[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+
+echo "ok"
+exit 0

--- a/operator/tests/test-update.sh
+++ b/operator/tests/test-update.sh
@@ -2,14 +2,26 @@
 
 set -e
 
+readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
+source "${ROOT_DIR}"/tests/functions.sh
+
+readonly NAMESPACE="tailing-sidecar-system"
+readonly TIME=300
+
+wait_for_all_pods_running ${NAMESPACE} ${TIME}
+
+readonly POD="pod-with-annotations"
+wait_for_pod ${NAMESPACE} ${POD} ${TIME}
+
 # Check Pod logs
-[[ $(kubectl logs pod-with-annotations tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs pod-with-annotations named-sidecar -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs pod-with-annotations tailing-sidecar-1 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${POD} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${POD} named-sidecar -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${POD} tailing-sidecar-1 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 # Check Deployment logs
-readonly DEPLOYMENT_POD_NAME="$(kubectl get pod -l app=deployment-with-annotations -n tailing-sidecar-system -o jsonpath="{.items[0].metadata.name}")"
-[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly DEPLOYMENT_POD_NAME="$(kubectl get pod -l app=deployment-with-annotations -n ${NAMESPACE} -o jsonpath="{.items[0].metadata.name}")"
+wait_for_pod ${NAMESPACE} ${DEPLOYMENT_POD_NAME} ${TIME}
+[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 echo "ok"
 exit 0

--- a/operator/tests/test.sh
+++ b/operator/tests/test.sh
@@ -2,26 +2,42 @@
 
 set -e
 
+readonly ROOT_DIR="$(dirname "$(dirname "${0}")")"
+source "${ROOT_DIR}"/tests/functions.sh
+
+readonly NAMESPACE="tailing-sidecar-system"
+readonly TIME=60
+
+wait_for_all_pods_running ${NAMESPACE} ${TIME}
+
 # Check Pod logs
-[[ $(kubectl logs pod-with-annotations tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs pod-with-annotations named-container -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly POD="pod-with-annotations"
+wait_for_pod ${NAMESPACE} ${POD} ${TIME}
+[[ $(kubectl logs ${POD} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${POD} named-container -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 # Check StatefulSet logs
-[[ $(kubectl logs statefulset-with-annotations-0 my-named-sidecar -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs statefulset-with-annotations-0 tailing-sidecar-1 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly STATEFULSET_POD_NAME="statefulset-with-annotations-0"
+wait_for_pod ${NAMESPACE} ${STATEFULSET_POD_NAME} ${TIME}
+[[ $(kubectl logs ${STATEFULSET_POD_NAME} my-named-sidecar -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${STATEFULSET_POD_NAME} tailing-sidecar-1 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 # Check Deployment logs
-readonly DEPLOYMENT_POD_NAME="$(kubectl get pod -l app=deployment-with-annotations -n tailing-sidecar-system -o jsonpath="{.items[0].metadata.name}")"
-[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-1 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly DEPLOYMENT_POD_NAME="$(kubectl get pod -l app=deployment-with-annotations -n ${NAMESPACE} -o jsonpath="{.items[0].metadata.name}")"
+wait_for_pod ${NAMESPACE} ${DEPLOYMENT_POD_NAME} ${TIME}
+[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${DEPLOYMENT_POD_NAME} tailing-sidecar-1 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 # Check Daemonset logs
-readonly DAEMONSET_POD_NAME="$(kubectl get pod -l app=daemonset-with-annotations -n tailing-sidecar-system -o jsonpath="{.items[0].metadata.name}")"
-[[ $(kubectl logs ${DAEMONSET_POD_NAME} tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
-[[ $(kubectl logs ${DAEMONSET_POD_NAME} tailing-sidecar-1 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly DAEMONSET_POD_NAME="$(kubectl get pod -l app=daemonset-with-annotations -n ${NAMESPACE} -o jsonpath="{.items[0].metadata.name}")"
+wait_for_pod ${NAMESPACE} ${DAEMONSET_POD_NAME} ${TIME}
+[[ $(kubectl logs ${DAEMONSET_POD_NAME} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+[[ $(kubectl logs ${DAEMONSET_POD_NAME} tailing-sidecar-1 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 # Test Pod with configuration in CRD
-[[ $(kubectl logs pod-with-annotations-crd tailing-sidecar-0 -n tailing-sidecar-system --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
+readonly POD_WITH_CRD="pod-with-annotations-crd"
+wait_for_pod ${NAMESPACE} ${POD_WITH_CRD} ${TIME}
+[[ $(kubectl logs ${POD_WITH_CRD} tailing-sidecar-0 -n ${NAMESPACE} --tail 5 | grep example | wc -l) -ne 5 ]] && exit 1
 
 echo "ok"
 exit 0


### PR DESCRIPTION
Testes with following script:
```
#/bin/bash

make deploy
make deploy-examples
make deploy-example-with-crd
sleep 5
make test-examples
make deploy-examples-update
make test-examples-update
```

with `kubectl wait` following error occured:
```
Error from server (NotFound): pods "pod-with-annotations-crd" not found
Makefile:108: recipe for target 'test-examples' failed
make: *** [test-examples] Error 1
```
but Pod was created in a second