### PR TITLE
Better handling for startupProbe and livenessProbe

### DIFF
--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -290,12 +290,22 @@ spec:
             scheme: HTTPS
             path: /add-tailing-sidecars-v1-pod
             port: 9443
+            httpHeaders:
+            - name: Accept
+              value: application/json
+            - name: Content-Type
+              value: application/json
           periodSeconds: 3
         livenessProbe:
           httpGet:
             scheme: HTTPS
             path: /add-tailing-sidecars-v1-pod
             port: 9443
+            httpHeaders:
+            - name: Accept
+              value: application/json
+            - name: Content-Type
+              value: application/json
           initialDelaySeconds: 1
           periodSeconds: 10
         resources:

--- a/operator/config/default/manager_webhook_patch.yaml
+++ b/operator/config/default/manager_webhook_patch.yaml
@@ -17,12 +17,22 @@ spec:
             scheme: HTTPS
             path: /add-tailing-sidecars-v1-pod
             port: 9443
+            httpHeaders:
+            - name: Accept
+              value: application/json
+            - name: Content-Type
+              value: application/json
           periodSeconds: 3
         livenessProbe:
           httpGet:
             scheme: HTTPS
             path: /add-tailing-sidecars-v1-pod
             port: 9443
+            httpHeaders:
+            - name: Accept
+              value: application/json
+            - name: Content-Type
+              value: application/json
           initialDelaySeconds: 1
           periodSeconds: 10
         volumeMounts:

--- a/operator/handler/handler.go
+++ b/operator/handler/handler.go
@@ -63,6 +63,10 @@ type PodExtender struct {
 
 // Handle handles requests to create/update Pod and extends it by adding tailing sidecars
 func (e *PodExtender) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation == "" {
+		return admission.Allowed("Received startupProbe/livenessProbe")
+	}
+
 	if req.Operation == admv1.Delete {
 		// eliminates hanging kubectl apply -f command
 		// kube-apiserver server waits for response from operator on DELETE request


### PR DESCRIPTION
Proper json request should have appropriate HTTP header:
```
Content-Type: application/json
Accept: application/json
```
this eliminates following error in operator logs: `2021-04-06T10:59:12.161Z        ERROR   controller-runtime.webhook.webhooks     unable to process a request with an unknown content type        {"webhook": "/add-tailing-sidecars-v1-pod", "content type": "", "error": "contentType=, expected application/json"}`

Add better handling for  startupProbe and livenessProbe in operator code to eliminate this errror:
`2021-04-06T11:23:46.412Z        DEBUG   controller-runtime.webhook.webhooks     wrote response  {"webhook": "/add-tailing-sidecars-v1-pod", "code": 400, "reason": "", "UID": "", "allowed": false}`
