### PR TITLE
feat: add Dockerfile and Makefile target to build UBI based container image

### DIFF
--- a/operator/Dockerfile.ubi
+++ b/operator/Dockerfile.ubi
@@ -1,0 +1,34 @@
+# Build the manager binary
+FROM golang:1.16.2 as builder
+
+WORKDIR /workspace
+
+# Copy the go source
+COPY . .
+
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+
+ARG VERSION=${VERSION}
+ARG RELEASE_NUMBER=${RELEASE_NUMBER}
+
+LABEL name="Tailing Sidecar Operator" \
+      maintainer="collection@sumologic.com" \
+      vendor="sumologic" \
+      version=${VERSION} \
+      release=${RELEASE_NUMBER} \
+      summary="Tailing Sidecar Operator" \
+      description="Tailing Sidecar Operator adds streaming sidecar containers which use tailing sidecar image to Pods"
+
+ADD https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/release-v0.3/LICENSE /licenses/LICENSE
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+
+ENTRYPOINT ["/manager"]

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -165,6 +165,10 @@ generate: controller-gen
 docker-build: test
 	docker build . -t ${IMG}
 
+# Build the docker image which bases on Red Hat Universal Base Image
+docker-build-ubi: test
+	docker build -t ${IMG} --build-arg VERSION=${VERSION} --build-arg RELEASE_NUMBER=${RELEASE_NUMBER} -f Dockerfile.ubi .
+
 # Push the docker image
 docker-push:
 	docker push ${IMG}


### PR DESCRIPTION
example command to build image:
```bash
make docker-build-ubi IMG=ghcr.io/kkujawa-sumo/tailing-sidecar-operator-ubi:test VERSION=0.3.1 RELEASE_NUMBER=6
```