### PR TITLE
feat: add Dockerfile and Makefile target to build UBI based sidecar container image

### DIFF
--- a/operator/Dockerfile.ubi
+++ b/operator/Dockerfile.ubi
@@ -20,11 +20,11 @@ ARG RELEASE_NUMBER=${RELEASE_NUMBER}
 
 LABEL name="Tailing Sidecar Operator" \
       maintainer="collection@sumologic.com" \
-      vendor="sumologic" \
+      vendor="Sumo Logic" \
       version=${VERSION} \
       release=${RELEASE_NUMBER} \
-      summary="Tailing Sidecar Operator" \
-      description="Tailing Sidecar Operator adds streaming sidecar containers which use tailing sidecar image to Pods"
+      summary="UBI based Tailing Sidecar Operator" \
+      description="Tailing Sidecar Operator adds streaming sidecar containers which use tailing sidecar image to Pods."
 
 ADD https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/release-v0.3/LICENSE /licenses/LICENSE
 

--- a/sidecar/Dockerfile.ubi
+++ b/sidecar/Dockerfile.ubi
@@ -11,11 +11,11 @@ ARG RELEASE_NUMBER=${RELEASE_NUMBER}
 
 LABEL name="Tailing Sidecar" \
       maintainer="collection@sumologic.com" \
-      vendor="sumologic" \
+      vendor="Sumo Logic" \
       version=${VERSION} \
       release=${RELEASE_NUMBER} \
-      summary="Tailing Sidecar" \
-      description="Tailing sidecar is a streaming sidecar container which can be used with Tailing Sidecar Operator"
+      summary="UBI based Tailing Sidecar" \
+      description="Tailing sidecar is a streaming sidecar container which can be used with Tailing Sidecar Operator."
 
 ADD https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/release-v0.3/LICENSE /licenses/LICENSE
 

--- a/sidecar/Dockerfile.ubi
+++ b/sidecar/Dockerfile.ubi
@@ -1,0 +1,32 @@
+FROM golang:1.16.2 as go-builder
+RUN mkdir /build
+ADD ./out_gstdout /build/
+WORKDIR /build
+RUN make all
+
+FROM public.ecr.aws/sumologic/fluent-bit:1.6.10-ubi
+
+ARG VERSION=${VERSION}
+ARG RELEASE_NUMBER=${RELEASE_NUMBER}
+
+LABEL name="Tailing Sidecar" \
+      maintainer="collection@sumologic.com" \
+      vendor="sumologic" \
+      version=${VERSION} \
+      release=${RELEASE_NUMBER} \
+      summary="Tailing Sidecar" \
+      description="Tailing sidecar is a streaming sidecar container which can be used with Tailing Sidecar Operator"
+
+ADD https://raw.githubusercontent.com/SumoLogic/tailing-sidecar/release-v0.3/LICENSE /licenses/LICENSE
+
+ENV LOG_LEVEL=warning
+
+COPY --from=go-builder \
+  /build/out_gstdout.so \
+  /tailing-sidecar/lib/
+
+COPY conf/fluent-bit.conf \
+  conf/plugins.conf \
+  /fluent-bit/etc/
+
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf", "--quiet"]

--- a/sidecar/Makefile
+++ b/sidecar/Makefile
@@ -14,6 +14,13 @@ all: build push
 build:
 	docker build --tag $(TAG) --file ${root_dir}sidecar/Dockerfile ${root_dir}sidecar/
 
+build-ubi:
+	docker build \
+		--tag $(TAG) \
+		--build-arg VERSION=${VERSION} \
+		--build-arg RELEASE_NUMBER=${RELEASE_NUMBER} \
+		--file ${root_dir}sidecar/Dockerfile.ubi ${root_dir}sidecar/
+
 run: build
 	docker run --rm -it \
 		-v $(DIR_TO_TAIL):/tmp/host \


### PR DESCRIPTION
example command to build image: 
```bash
make build-ubi TAG=ghcr.io/kkujawa-sumo/tailing-sidecar-ubi:test VERSION=0.3.1 RELEASE_NUMBER=6
```