### PR TITLE
ci: use only latest Golang version

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -40,15 +40,12 @@ jobs:
   build-operator:
     name: Build tailing sidecar operator
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        go: [ '1.15', '1.14' ]
     steps:
       - uses: actions/checkout@v2
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go }}
+          go-version: '1.17'
       - name: Run tests for tailing sidecar operator
         working-directory: ./operator
         run: make test


### PR DESCRIPTION
There is no purpose in testing with Go versions other than the one specified in the Dockerfile, which should be the latest stable Golang version.