### PR TITLE
chore: upgrade kube-rbac-proxy from 0.5.0 to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- chore: upgrade kube-rbac-proxy from 0.5.0 to 0.11.0 [#280]
+- chore: change container repository for kube-rbac-proxy to quay.io/brancz/kube-rbac-proxy [#280]
+
+[#280]: https://github.com/SumoLogic/tailing-sidecar/pull/280
+
 ## [v0.5.1] - 2022-02-02
 
 - chore: update Golang from 1.16.5 to 1.17.6 [#212] [#213] [#231] [#232] [#247] [#248] [#256] [#257]

--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -24,8 +24,8 @@ sidecar:
 kubeRbacProxy:
   image:
     pullPolicy: IfNotPresent
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    tag: v0.5.0
+    repository: quay.io/brancz/kube-rbac-proxy
+    tag: v0.11.0
 
 # Configuration for MutatingWebhook which is used by tailing sidecar operator
 # for details please see Kubernetes API Reference Docs

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
- chore: upgrade kube-rbac-proxy from 0.5.0 to 0.11.0

- chore: change container repository for kube-rbac-proxy to `quay.io/brancz/kube-rbac-proxy`
which is the official container repository for https://github.com/brancz/kube-rbac-proxy
see also: https://github.com/brancz/kube-rbac-proxy/blob/4f59920d1164aa804d94f5207451b0450831556b/Makefile#L13

related to #170 