### PR TITLE
fix: github action for builing dev and releases images

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -41,6 +41,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.4.0
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - name: Extract tag
         id: extract_tag
         run: echo "::set-output name=tag::$(echo $(git describe --tags --always))"

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -41,6 +41,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.4.0
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17'
       - name: Extract tag
         id: extract_tag
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"


### PR DESCRIPTION
set go version to 1.17, 
fixes following error: https://github.com/SumoLogic/tailing-sidecar/runs/5249530879?check_suite_focus=true