### PR TITLE
fix(chart): add permissions for leases

### DIFF
--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -104,6 +104,22 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - 7b555970.sumologic.com
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This fixes the error "error retrieving resource lock namespace/7b555970.sumologic.com: leases.coordination.k8s.io "7b555970.sumologic.com" is forbidden"