### PR TITLE
chore: fix mdl check

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: '2.6'
+          ruby-version: '2.7'
       - name: install markdownlint
         run: gem install mdl
       - name: markdownlint check


### PR DESCRIPTION
Fixes: https://github.com/SumoLogic/tailing-sidecar/actions/runs/3358738681/jobs/5566068791
```
ERROR:  Error installing mdl:
	The last version of mdl (>= 0) to support your Ruby & RubyGems was 0.11.0. Try installing it with `gem install mdl -v 0.11.0`
	mdl requires Ruby version >= 2.7. The current ruby version is 2.6.10.210.
```
