### PR TITLE
fix: remove update operation from pod from mutatingWebhookConfigurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- fix: remove update operation from pod from mutatingWebhookConfigurations [#413]
+
+[#413]: https://github.com/SumoLogic/tailing-sidecar/pull/413
+
 ## [v0.5.4] - 2022-09-26
 
 - chore: upgrade libc and zlib in the Dockerfile [#392]

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook-with-cert-manager.tpl
@@ -30,7 +30,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     - DELETE
     resources:
     - pods

--- a/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
+++ b/helm/tailing-sidecar-operator/templates/_operator-webhook.tpl
@@ -31,7 +31,6 @@ webhooks:
     - v1beta1
     operations:
     - CREATE
-    - UPDATE
     - DELETE
     resources:
     - pods

--- a/operator/config/webhook/manifests.yaml
+++ b/operator/config/webhook/manifests.yaml
@@ -24,7 +24,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     - DELETE
     resources:
     - pods


### PR DESCRIPTION
Justification:

getting rid of
```
 * spec.containers: Forbidden: pod updates may not add or remove containers
```
error

I tested in on deployment and editing the pod template is creating new replicaSet and new Pod with annotation change