### PR TITLE
Revert "build(deps): bump fluent/fluent-bit from 1.9.9 to 2.0.8 in /sidecar"

### DIFF
--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 RUN find /dpkg/ -type d -empty -delete && \
     rm -r /dpkg/usr/share/doc/
 
-FROM fluent/fluent-bit:2.0.8
+FROM fluent/fluent-bit:1.9.9
 ENV LOG_LEVEL=warning
 
 # Copy the libraries from the extractor stage into root


### PR DESCRIPTION
Reverts SumoLogic/tailing-sidecar#441