### PR TITLE
chore: fix building sidecar image

### DIFF
--- a/sidecar/Makefile
+++ b/sidecar/Makefile
@@ -25,7 +25,7 @@ build-push-multiplatform:
 	docker buildx build \
 		--push \
 		--platform linux/amd64,linux/arm/v7,linux/arm64 \
-		--tag ${IMG} \
+		--tag ${TAG} \
 		.
 
 push:


### PR DESCRIPTION
Fixes (https://github.com/SumoLogic/tailing-sidecar/actions/runs/3871815146/jobs/6599958446):

```
  docker tag ghcr.io/sumologic/tailing-sidecar:167b365 ghcr.io/sumologic/tailing-sidecar:main
  shell: /usr/bin/bash -e {0}
  env:
    SIDECAR_IMAGE: ghcr.io/sumologic/tailing-sidecar
    OPERATOR_IMAGE: ghcr.io/sumologic/tailing-sidecar-operator
    LATEST_TAG: main
Error response from daemon: No such image: ghcr.io/sumologic/tailing-sidecar:167b365
```