### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -20,9 +20,12 @@ jobs:
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
       - name: Print container tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
-      - name: Build tailing sidecar image
-        run: make build TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
-        working-directory: ./sidecar
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.2.1
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2.1.0
         with:


### PR DESCRIPTION
Fixes:
```
  shell: /usr/bin/bash -e {0}
  env:
    SIDECAR_IMAGE: ghcr.io/sumologic/tailing-sidecar
    OPERATOR_IMAGE: ghcr.io/sumologic/tailing-sidecar-operator
    LATEST_TAG: latest
docker buildx build \
	--push \
	--platform linux/amd64,linux/arm/v7,linux/arm64 \
	--tag ghcr.io/sumologic/tailing-sidecar:0.5.6 \
	.
ERROR: multiple platforms feature is currently not supported for docker driver. Please switch to a different driver (eg. "docker buildx create --use")
```