### PR TITLE
fix(ci): fix pushing images to container registry

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -10,8 +10,8 @@ env:
   SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"
   OPERATOR_IMAGE: "ghcr.io/sumologic/tailing-sidecar-operator"
   ECR_URL: public.ecr.aws/sumologic
-  SIDECAR_IMAGE_ECR: "${{ env.ECR_URL }}/sumologic/tailing-sidecar"
-  OPERATOR_IMAGE_ECR: "${{ env.ECR_URL }}/sumologic/tailing-sidecar-operator"
+  SIDECAR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar"
+  OPERATOR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-operator"
   LATEST_TAG: "main"
 
 jobs:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -9,8 +9,8 @@ env:
   SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"
   OPERATOR_IMAGE: "ghcr.io/sumologic/tailing-sidecar-operator"
   ECR_URL: public.ecr.aws/sumologic
-  SIDECAR_IMAGE_ECR: "${{ env.ECR_URL }}/sumologic/tailing-sidecar-dev"
-  OPERATOR_IMAGE_ECR: "${{ env.ECR_URL }}/sumologic/tailing-sidecar-operator-dev"
+  SIDECAR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-dev"
+  OPERATOR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-operator-dev"
   LATEST_TAG: "latest"
 
 jobs:


### PR DESCRIPTION
following problem is now observed in workflow:
```


Invalid workflow file: .github/workflows/dev_builds.yml#L13The workflow is not valid. .github/workflows/dev_builds.yml (Line: 13, Col: 22): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ECR_URL .github/workflows/dev_builds.yml (Line: 14, Col: 23): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ECR_URL
--


[Invalid workflow file: .github/workflows/dev_builds.yml#L13](https://github.com/SumoLogic/tailing-sidecar/actions/runs/4489527193/workflow)
The workflow is not valid. .github/workflows/dev_builds.yml (Line: 13, Col: 22): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ECR_URL .github/workflows/dev_builds.yml (Line: 14, Col: 23): Unrecognized named-value: 'env'. Located at position 1 within expression: env.ECR_URL
```