### PR TITLE
chore: prepare v0.7.0

### DIFF
--- a/helm/tailing-sidecar-operator/Chart.yaml
+++ b/helm/tailing-sidecar-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tailing-sidecar-operator
 description: Installs Tailing Sidecar Operator
 type: application
-version: 0.6.0
-appVersion: 0.6.0
+version: 0.7.0
+appVersion: 0.7.0
 keywords:
   - tailing-sidecar
   - k8s-logging


### PR DESCRIPTION
Changes:

- bb331ab build(deps): bump golang from 1.20.1 to 1.20.2 in /sidecar
- e6d2e7d build(deps): bump golang from 1.20.2 to 1.20.3 in /sidecar
- ea06443 build(deps): bump fluent/fluent-bit from 1.9.9 to 2.0.10 in /sidecar

Using minor version because of fluentd upgrade from 1.x.x to 2.y.y