### PR TITLE
Fix deprecations in github actions

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo $(git describe --tags --always))"
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
       - name: Print container tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
 
@@ -64,7 +64,7 @@ jobs:
           go-version: '1.20'
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo $(git describe --tags --always))"
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
       - name: Print container tag
         run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
 

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
       - name: Print container tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
 
@@ -63,7 +63,7 @@ jobs:
           go-version: '1.20'
       - name: Extract tag
         id: extract_tag
-        run: echo "::set-output name=tag::$(echo ${GITHUB_REF#refs/tags/v})"
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
       - name: Print container tag
         run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
 


### PR DESCRIPTION
remove set-output based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/