### PR TITLE
feat(helm): use configmap to configure tailing-sidecar-operator

### DIFF
--- a/helm/tailing-sidecar-operator/conf/operator.yaml
+++ b/helm/tailing-sidecar-operator/conf/operator.yaml
@@ -1,0 +1,2 @@
+sidecar:
+  image: {{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}

--- a/helm/tailing-sidecar-operator/templates/_helpers.tpl
+++ b/helm/tailing-sidecar-operator/templates/_helpers.tpl
@@ -49,3 +49,10 @@ Selector labels
 app.kubernetes.io/name: {{ include "tailing-sidecar-operator.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Configmap name
+*/}}
+{{- define "tailing-sidecar-operator.configMap.name" -}}
+{{- printf "%s-%s" .Release.Name "operator-config" | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/helm/tailing-sidecar-operator/templates/configmap.yaml
+++ b/helm/tailing-sidecar-operator/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "tailing-sidecar-operator.configMap.name" . }}
+  labels:
+    {{- include "tailing-sidecar-operator.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+  {{- (tpl (.Files.Get "conf/operator.yaml") .) | nindent 4 }}

--- a/helm/tailing-sidecar-operator/templates/resources.yaml
+++ b/helm/tailing-sidecar-operator/templates/resources.yaml
@@ -368,6 +368,8 @@ spec:
     metadata:
       labels:
         {{- include "tailing-sidecar-operator.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
       - args:
@@ -384,7 +386,7 @@ spec:
       - args:
         - --metrics-addr=127.0.0.1:8080
         - --enable-leader-election
-        - --tailing-sidecar-image={{ .Values.sidecar.image.repository }}:{{ .Values.sidecar.image.tag | default .Chart.AppVersion }}
+        - --config=/tailing-sidecar/config/config.yaml
         command:
         - /manager
         image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
@@ -431,6 +433,9 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
+        - mountPath: /tailing-sidecar/config
+          name: config
+          readOnly: true
       serviceAccountName: tailing-sidecar-service-account
       terminationGracePeriodSeconds: 10
       volumes:
@@ -438,3 +443,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
+      - name: config
+        configMap:
+          name: {{ template "tailing-sidecar-operator.configMap.name" . }}


### PR DESCRIPTION
Use configmap in helm chart to provide configuration for sidecar operator.

This is another step for https://github.com/SumoLogic/tailing-sidecar/pull/467
The last step will be adding `customConfigmap` (content or name), which will be injected into sidecar, which is going to allow to override fluent-bit configuration