### PR TITLE
chore(sidecar): update fluent-bit to 2.1.7

### DIFF
--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 RUN find /dpkg/ -type d -empty -delete && \
     rm -r /dpkg/usr/share/doc/
 
-FROM fluent/fluent-bit:2.0.11
+FROM fluent/fluent-bit:2.1.7
 ENV LOG_LEVEL=warning
 
 # Copy the libraries from the extractor stage into root

--- a/sidecar/out_gstdout/go.mod
+++ b/sidecar/out_gstdout/go.mod
@@ -1,5 +1,7 @@
 module github.com/fluent/fluent-bit-go/examples/gstdout
 
-go 1.14
+go 1.20
 
 require github.com/fluent/fluent-bit-go v0.0.0-20201210173045-3fd1e0486df2
+
+require github.com/ugorji/go/codec v1.1.7 // indirect

--- a/sidecar/out_gstdout/go.sum
+++ b/sidecar/out_gstdout/go.sum
@@ -1,6 +1,5 @@
 github.com/fluent/fluent-bit-go v0.0.0-20201210173045-3fd1e0486df2 h1:G57WNyWS0FQf43hjRXLy5JT1V5LWVsSiEpkUcT67Ugk=
 github.com/fluent/fluent-bit-go v0.0.0-20201210173045-3fd1e0486df2/go.mod h1:L92h+dgwElEyUuShEwjbiHjseW410WIcNz+Bjutc8YQ=
-github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=


### PR DESCRIPTION
Update fluent-bit in order to mitigate medium and high severities:

before:

```
✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Authentication Bypass
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-1291054
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Link Following
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-524969
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733387
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733391
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733392
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in postgresql-13/libpq5
  Description: CVE-2022-41862
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-POSTGRESQL13-3318091
  Introduced through: postgresql-13/libpq5@13.9-0+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1

✗ Low severity vulnerability found in openssl/libssl1.1
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-518334
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...

✗ Low severity vulnerability found in openssl/libssl1.1
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-525332
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Improper Initialization
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-521320
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.9-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Out-of-Bounds
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-531344
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.9-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-531747
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.9-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: NULL Pointer Dereference
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-5660622
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.9-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-584937
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.9-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in libzstd/libzstd1
  Description: Resource Exhaustion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBZSTD-5406388
  Introduced through: libzstd/libzstd1@1.4.8+dfsg-2.1, systemd/libsystemd0@252.5-2~bpo11+1
  From: libzstd/libzstd1@1.4.8+dfsg-2.1
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libzstd/libzstd1@1.4.8+dfsg-2.1

✗ Low severity vulnerability found in libgcrypt20
  Description: Information Exposure
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBGCRYPT20-1297892
  Introduced through: libgcrypt20@1.8.7-6, systemd/libsystemd0@252.5-2~bpo11+1
  From: libgcrypt20@1.8.7-6
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libgcrypt20@1.8.7-6

✗ Low severity vulnerability found in libgcrypt20
  Description: Use of a Broken or Risky Cryptographic Algorithm
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBGCRYPT20-523947
  Introduced through: libgcrypt20@1.8.7-6, systemd/libsystemd0@252.5-2~bpo11+1
  From: libgcrypt20@1.8.7-6
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libgcrypt20@1.8.7-6

✗ Low severity vulnerability found in krb5/libkrb5support0
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-KRB5-524883
  Introduced through: krb5/libkrb5support0@1.18.3-6+deb11u3, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, krb5/libk5crypto3@1.18.3-6+deb11u3, krb5/libkrb5-3@1.18.3-6+deb11u3, postgresql-13/libpq5@13.9-0+deb11u1
  From: krb5/libkrb5support0@1.18.3-6+deb11u3
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libkrb5support0@1.18.3-6+deb11u3
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libk5crypto3@1.18.3-6+deb11u3 > krb5/libkrb5support0@1.18.3-6+deb11u3
  and 8 more...

✗ Low severity vulnerability found in gnutls28/libgnutls30
  Description: Improper Input Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GNUTLS28-515971
  Introduced through: gnutls28/libgnutls30@3.7.1-5+deb11u3, openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: gnutls28/libgnutls30@3.7.1-5+deb11u3
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1 > gnutls28/libgnutls30@3.7.1-5+deb11u3

✗ Low severity vulnerability found in glibc/libc6
  Description: Out-of-Bounds
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-521063
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Uncontrolled Recursion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-521199
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Use of Insufficiently Random Values
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-522385
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Information Exposure
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-529848
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: CVE-2019-1010023
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-531451
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Uncontrolled Recursion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-531492
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Resource Management Errors
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-532215
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in e2fsprogs/libcom-err2
  Description: Out-of-bounds Read
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-E2FSPROGS-2628459
  Introduced through: e2fsprogs/libcom-err2@1.46.2-2, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3
  From: e2fsprogs/libcom-err2@1.46.2-2
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > e2fsprogs/libcom-err2@1.46.2-2
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libkrb5-3@1.18.3-6+deb11u3 > e2fsprogs/libcom-err2@1.46.2-2

✗ Medium severity vulnerability found in postgresql-13/libpq5
  Description: CVE-2023-2455
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-POSTGRESQL13-5519351
  Introduced through: postgresql-13/libpq5@13.9-0+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1
  Fixed in: 13.11-0+deb11u1

✗ Medium severity vulnerability found in openssl/libssl1.1
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-5291773
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...
  Fixed in: 1.1.1n-0+deb11u5

✗ Medium severity vulnerability found in openssl/libssl1.1
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-5291777
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...
  Fixed in: 1.1.1n-0+deb11u5

✗ High severity vulnerability found in postgresql-13/libpq5
  Description: CVE-2023-2454
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-POSTGRESQL13-5519349
  Introduced through: postgresql-13/libpq5@13.9-0+deb11u1
  From: postgresql-13/libpq5@13.9-0+deb11u1
  Fixed in: 13.11-0+deb11u1

✗ High severity vulnerability found in openssl/libssl1.1
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-3368735
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...
  Fixed in: 1.1.1n-0+deb11u5

✗ High severity vulnerability found in openssl/libssl1.1
  Description: Allocation of Resources Without Limits or Throttling
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-5661566
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u4, postgresql-13/libpq5@13.9-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u4
  From: openssl/libssl1.1@1.1.1n-0+deb11u4
  From: postgresql-13/libpq5@13.9-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u4
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u4 > openssl/libssl1.1@1.1.1n-0+deb11u4
  and 3 more...
  Fixed in: 1.1.1n-0+deb11u5



Organization:      sumologic
Package manager:   deb
Project name:      docker-image|public.ecr.aws/sumologic/tailing-sidecar
Docker image:      public.ecr.aws/sumologic/tailing-sidecar:latest
Platform:          linux/amd64
Licenses:          enabled

Tested 39 dependencies for known issues, found 32 issues.
[32mINFO    [0m root:command_executor.py:26 
```

after:

```
Testing localhost:32000/sumologic/tailing-sidecar:latest...

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Authentication Bypass
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-1291054
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Link Following
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-524969
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733387
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733391
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in systemd/libsystemd0
  Description: Improper Validation of Integrity Check Value
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-SYSTEMD-5733392
  Introduced through: systemd/libsystemd0@252.5-2~bpo11+1
  From: systemd/libsystemd0@252.5-2~bpo11+1

✗ Low severity vulnerability found in postgresql-13/libpq5
  Description: CVE-2022-41862
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-POSTGRESQL13-3318091
  Introduced through: postgresql-13/libpq5@13.11-0+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1

✗ Low severity vulnerability found in openssl/libssl1.1
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-518334
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u5, postgresql-13/libpq5@13.11-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u5
  From: openssl/libssl1.1@1.1.1n-0+deb11u5
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u5
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u5 > openssl/libssl1.1@1.1.1n-0+deb11u5
  and 3 more...

✗ Low severity vulnerability found in openssl/libssl1.1
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENSSL-525332
  Introduced through: openssl/libssl1.1@1.1.1n-0+deb11u5, postgresql-13/libpq5@13.11-0+deb11u1, ca-certificates@20210119, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, openssl@1.1.1n-0+deb11u5
  From: openssl/libssl1.1@1.1.1n-0+deb11u5
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openssl/libssl1.1@1.1.1n-0+deb11u5
  From: ca-certificates@20210119 > openssl@1.1.1n-0+deb11u5 > openssl/libssl1.1@1.1.1n-0+deb11u5
  and 3 more...

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Improper Initialization
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-521320
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.11-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Out-of-Bounds
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-531344
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.11-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Cryptographic Issues
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-531747
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.11-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: NULL Pointer Dereference
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-5660622
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.11-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in openldap/libldap-2.4-2
  Description: Improper Certificate Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-OPENLDAP-584937
  Introduced through: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1, postgresql-13/libpq5@13.11-0+deb11u1
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: postgresql-13/libpq5@13.11-0+deb11u1 > openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1

✗ Low severity vulnerability found in libzstd/libzstd1
  Description: Resource Exhaustion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBZSTD-5406388
  Introduced through: libzstd/libzstd1@1.4.8+dfsg-2.1, systemd/libsystemd0@252.5-2~bpo11+1
  From: libzstd/libzstd1@1.4.8+dfsg-2.1
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libzstd/libzstd1@1.4.8+dfsg-2.1

✗ Low severity vulnerability found in libgcrypt20
  Description: Information Exposure
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBGCRYPT20-1297892
  Introduced through: libgcrypt20@1.8.7-6, systemd/libsystemd0@252.5-2~bpo11+1
  From: libgcrypt20@1.8.7-6
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libgcrypt20@1.8.7-6

✗ Low severity vulnerability found in libgcrypt20
  Description: Use of a Broken or Risky Cryptographic Algorithm
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-LIBGCRYPT20-523947
  Introduced through: libgcrypt20@1.8.7-6, systemd/libsystemd0@252.5-2~bpo11+1
  From: libgcrypt20@1.8.7-6
  From: systemd/libsystemd0@252.5-2~bpo11+1 > libgcrypt20@1.8.7-6

✗ Low severity vulnerability found in krb5/libkrb5support0
  Description: Integer Overflow or Wraparound
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-KRB5-524883
  Introduced through: krb5/libkrb5support0@1.18.3-6+deb11u3, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3, krb5/libk5crypto3@1.18.3-6+deb11u3, krb5/libkrb5-3@1.18.3-6+deb11u3, postgresql-13/libpq5@13.11-0+deb11u1
  From: krb5/libkrb5support0@1.18.3-6+deb11u3
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libkrb5support0@1.18.3-6+deb11u3
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libk5crypto3@1.18.3-6+deb11u3 > krb5/libkrb5support0@1.18.3-6+deb11u3
  and 8 more...

✗ Low severity vulnerability found in gnutls28/libgnutls30
  Description: Improper Input Validation
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GNUTLS28-515971
  Introduced through: gnutls28/libgnutls30@3.7.1-5+deb11u3, openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1
  From: gnutls28/libgnutls30@3.7.1-5+deb11u3
  From: openldap/libldap-2.4-2@2.4.57+dfsg-3+deb11u1 > gnutls28/libgnutls30@3.7.1-5+deb11u3

✗ Low severity vulnerability found in glibc/libc6
  Description: Out-of-Bounds
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-521063
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Uncontrolled Recursion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-521199
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Use of Insufficiently Random Values
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-522385
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Information Exposure
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-529848
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: CVE-2019-1010023
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-531451
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Uncontrolled Recursion
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-531492
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in glibc/libc6
  Description: Resource Management Errors
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-GLIBC-532215
  Introduced through: meta-common-packages@meta
  From: meta-common-packages@meta > glibc/libc6@2.36-9

✗ Low severity vulnerability found in e2fsprogs/libcom-err2
  Description: Out-of-bounds Read
  Info: https://security.snyk.io/vuln/SNYK-DEBIAN11-E2FSPROGS-2628459
  Introduced through: e2fsprogs/libcom-err2@1.46.2-2, krb5/libgssapi-krb5-2@1.18.3-6+deb11u3
  From: e2fsprogs/libcom-err2@1.46.2-2
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > e2fsprogs/libcom-err2@1.46.2-2
  From: krb5/libgssapi-krb5-2@1.18.3-6+deb11u3 > krb5/libkrb5-3@1.18.3-6+deb11u3 > e2fsprogs/libcom-err2@1.46.2-2
```