### PR TITLE
ci: upgrade e2e k8s version to 1.27

### DIFF
--- a/kind.yaml
+++ b/kind.yaml
@@ -1,5 +1,6 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+name: tailing-sidecar-operator-e2e
 nodes:
   - role: control-plane
-    image: kindest/node:v1.24.15@sha256:7db4f8bea3e14b82d12e044e25e34bd53754b7f2b0e9d56df21774e6f66a70ab
+    image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72


### PR DESCRIPTION
We should define which versions we support and run tests on the oldest and latest. For now though, just latest is fine.