### PR TITLE
feat: add experimental otelcol sidecar

### DIFF
--- a/sidecar/otelcol/.gitignore
+++ b/sidecar/otelcol/.gitignore
@@ -1,0 +1,3 @@
+bin/
+cmd/
+dist/

--- a/sidecar/otelcol/.goreleaser.yaml
+++ b/sidecar/otelcol/.goreleaser.yaml
@@ -1,0 +1,63 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 1
+
+project_name: otelcol-sidecar
+
+before:
+  hooks:
+    - make generate-sources VERSION={{ .Version }}
+
+builds:
+  - main: ./cmd
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
+# disable archiving
+archives:
+  - format: binary
+
+dockers:
+  - image_templates:
+      - "ghcr.io/sumologic/tailing-sidecar-otel:{{ .Version }}-amd64"
+      - "ghcr.io/sumologic/tailing-sidecar-otel:latest-amd64"
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+    extra_files:
+      - "config.yaml"
+  - image_templates:
+      - "ghcr.io/sumologic/tailing-sidecar-otel:{{ .Version }}-arm64"
+      - "ghcr.io/sumologic/tailing-sidecar-otel:latest-arm64"
+    use: buildx
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+    extra_files:
+      - "config.yaml"
+
+docker_manifests:
+  - name_template: "ghcr.io/sumologic/tailing-sidecar-otel:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/sumologic/tailing-sidecar-otel:{{ .Version }}-amd64"
+      - "ghcr.io/sumologic/tailing-sidecar-otel:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/sumologic/tailing-sidecar-otel:latest"
+    image_templates:
+      - "ghcr.io/sumologic/tailing-sidecar-otel:latest-amd64"
+      - "ghcr.io/sumologic/tailing-sidecar-otel:latest-arm64"
+
+# we only want to build and publish docker images
+release:
+  disable: true

--- a/sidecar/otelcol/.goreleaser.yaml
+++ b/sidecar/otelcol/.goreleaser.yaml
@@ -15,7 +15,7 @@ before:
     - make generate-sources VERSION={{ .Version }}
 
 builds:
-  - main: ./cmd
+  - dir: ./cmd
     env:
       - CGO_ENABLED=0
     goos:

--- a/sidecar/otelcol/.otelcol-builder.yaml
+++ b/sidecar/otelcol/.otelcol-builder.yaml
@@ -1,0 +1,33 @@
+dist:
+  name: otelcol-sidecar
+  description: Sumo Logic OpenTelemetry Collector Sidecar distribution
+  # the module name for the new distribution, following Go mod conventions. Optional, but recommended.
+  module: github.com/SumoLogic/tailing-sidecar/sidecar
+  # the OpenTelemetry Collector version to use as base for the distribution.
+  otelcol_version: 0.90.1
+  # the path to write the output (sources and binary).
+  output_path: ./cmd
+
+exporters:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.90.1
+
+# Note: These components aren't strictly necessary, but they don't measurably increase the binary size
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.90.1
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.90.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor v0.90.1
+
+receivers:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.90.1
+
+extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.90.1
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.90.1
+    import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/filestorage
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.90.1
+    import: github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension
+
+# Replacement paths are relative to the output_path (location of source files)
+replaces:
+  - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter => github.com/SumoLogic/opentelemetry-collector-contrib/exporter/fileexporter 687035f9f64c57e96d74d523b398f526e698f9e4
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/textencodingextension =>  github.com/SumoLogic/opentelemetry-collector-contrib/extension/encoding/textencodingextension 687035f9f64c57e96d74d523b398f526e698f9e4

--- a/sidecar/otelcol/Dockerfile
+++ b/sidecar/otelcol/Dockerfile
@@ -16,6 +16,6 @@ COPY --from=directories --chown=${USER_UID}:${USER_UID} /var/log/otelcol.log /va
 # copy the default tailing-sidecar configuration file
 COPY ./config.yaml /etc/otel/config.yaml
 
-COPY otelcol-sidecar /
-ENTRYPOINT ["/otelcol-sidecar"]
+COPY otelcol-sidecar /otelcol
+ENTRYPOINT ["/otelcol"]
 CMD ["--config", "/etc/otel/config.yaml"]

--- a/sidecar/otelcol/Dockerfile
+++ b/sidecar/otelcol/Dockerfile
@@ -1,0 +1,21 @@
+# Prepare the necessary directories in an Alpine container where we have the necessary tooling
+FROM alpine:3.19.0 as directories
+RUN mkdir /etc/otel/
+RUN mkdir /var/lib/otc
+RUN touch /var/log/otelcol.log
+
+FROM scratch
+
+ARG USER_UID=10001
+USER ${USER_UID}
+
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /etc/otel/ /etc/otel/
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /var/lib/otc /var/lib/otc
+COPY --from=directories --chown=${USER_UID}:${USER_UID} /var/log/otelcol.log /var/log/otelcol.log
+
+# copy the default tailing-sidecar configuration file
+COPY ./config.yaml /etc/otel/config.yaml
+
+COPY otelcol-sidecar /
+ENTRYPOINT ["/otelcol-sidecar"]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/sidecar/otelcol/Makefile
+++ b/sidecar/otelcol/Makefile
@@ -1,0 +1,67 @@
+BINARY_NAME ?= otelcol-sidecar
+OTELCOL_VERSION ?= 0.90.1
+BUILDER_REPO ?= github.com/open-telemetry/opentelemetry-collector
+GO ?= go
+
+OS ?= $(shell uname -s | tr A-Z a-z)
+ARCH ?= $(shell uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+LOCALBIN ?= ./bin
+
+GORELEASER ?= $(LOCALBIN)/goreleaser
+
+BUILDER_BIN_NAME ?= opentelemetry-collector-builder$(BUILDER_BIN_EXT)
+BUILDER_BIN_PATH ?= $(LOCALBIN)
+BUILDER=$(BUILDER_BIN_PATH)/$(BUILDER_BIN_NAME)
+
+INSTALLED_VERSION := $(shell $(BUILDER) version 2>&1)
+
+# go-get-tool will 'go get' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-get-tool
+@[ -f $(1) ] || { \
+set -e ;\
+TMP_DIR=$$(mktemp -d) ;\
+cd $$TMP_DIR ;\
+go mod init tmp ;\
+echo "Downloading $(2)" ;\
+go get -d $(2)@$(3) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+rm -rf $$TMP_DIR ;\
+}
+endef
+
+.PHONY: install-builder
+install-builder:
+	@mkdir -p "$(BUILDER_BIN_PATH)"
+	curl -L -o "$(BUILDER_BIN_PATH)/$(BUILDER_BIN_NAME)" https://$(BUILDER_REPO)/releases/download/cmd/builder/v$(OTELCOL_VERSION)/ocb_$(OTELCOL_VERSION)_$(OS)_$(ARCH)$(BUILDER_BIN_EXT)
+	@chmod +x "$(BUILDER_BIN_PATH)/$(BUILDER_BIN_NAME)"
+	@$(MAKE) ensure-correct-builder-version
+
+.PHONY: install-goreleaser
+install-goreleaser:
+	$(call go-get-tool,$(GORELEASER),github.com/goreleaser/goreleaser,latest)
+
+
+.PHONY: ensure-correct-builder-version
+ensure-correct-builder-version:
+ifneq ($(lastword $(INSTALLED_VERSION)),$(OTELCOL_VERSION))
+	@$(error Installed opentelemetry-collector-builder version \
+		"$(INSTALLED_VERSION)" \
+		does not match the requested "$(OTELCOL_VERSION)" \
+		Please check if "$(BUILDER_BIN_PATH)" can be found in your PATH \
+		and if not, then install it using 'make install-builder' from otelcolbuilder's directory\
+	)
+endif
+
+.PHONY: build
+build: ensure-correct-builder-version install-goreleaser
+	@$(GORELEASER) release --snapshot --clean
+
+.PHONY: generate-sources
+generate-sources:
+	$(BUILDER_BIN_NAME) \
+		--go $(GO) \
+		--version "$(VERSION)" \
+		--config .otelcol-builder.yaml \
+		--skip-compilation=true
+

--- a/sidecar/otelcol/config.yaml
+++ b/sidecar/otelcol/config.yaml
@@ -1,0 +1,31 @@
+receivers:
+  filelog:
+    include:
+    - ${PATH_TO_TAIL}
+    start_at: beginning
+    storage: file_storage
+
+exporters:
+  file:
+    path: /dev/stdout
+    encoding: text_encoding
+
+extensions:
+  text_encoding:
+  file_storage:
+    directory: /var/lib/otc
+
+service:
+  extensions:
+    - text_encoding
+    - file_storage
+  telemetry:
+    metrics:
+      level: none
+    logs:
+      output_paths:
+        - /var/log/otelcol.log
+  pipelines:
+    logs:
+      exporters: [file]
+      receivers: [filelog]


### PR DESCRIPTION
Add the build infrastructure for a sidecar using Otelcol. This isn't used anywhere yet, and only allows the sidecar to be built locally. We use otelcolbuilder and goreleaser, plus a Makefile to manage them.