### PR TITLE
ci: fix otelcol sidecar dev build

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
       - name: Setup go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
For the otelcol sidecar, we actually need the tag to be semver compliant, so the dev version needs to include the previous git tag. This means that we also need to fetch tags when checking out the repository.