### PR TITLE
ci: use a treeless git clone for otel sidecar dev builds

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -59,7 +59,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true
+          filter: tree:0
+          fetch-depth: 0
       - name: Setup go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
I'd like to avoid a full clone here, so I'm going to try a treeless clone instead. See https://github.com/actions/checkout/issues/1152 for reference.