### PR TITLE
chore: rename sidecar image in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ login-ecr:
 
 .PHONY: e2e
 e2e: IMG="registry.localhost:5000/sumologic/tailing-sidecar-operator:test"
-e2e: TAILING_SIDECAR_IMG = "registry.localhost:5000/sumologic/tailing-sidecar:test"
+e2e: TAILING_SIDECAR_IMG = "registry.localhost:5000/sumologic/sidecar:test"
 e2e:
 	$(MAKE) -C ./sidecar/$(TAILING_SIDECAR) build-test-image TAG=$(TAILING_SIDECAR_IMG)
 	$(MAKE) -C ./operator docker-build IMG=$(IMG) TAILING_SIDECAR_IMG=$(TAILING_SIDECAR_IMG)

--- a/helm/tests/values.withCertManager.yaml
+++ b/helm/tests/values.withCertManager.yaml
@@ -5,7 +5,7 @@ operator:
 
 sidecar:
   image:
-    repository: registry.localhost:5000/sumologic/tailing-sidecar
+    repository: registry.localhost:5000/sumologic/sidecar
     tag: test
   resources:
     limits:

--- a/helm/tests/values.withFluentBitCustomConfiguration.yaml
+++ b/helm/tests/values.withFluentBitCustomConfiguration.yaml
@@ -5,7 +5,7 @@ operator:
 
 sidecar:
   image:
-    repository: registry.localhost:5000/sumologic/tailing-sidecar
+    repository: registry.localhost:5000/sumologic/sidecar
     tag: test
 
   resources:

--- a/helm/tests/values.withOtelcolCustomConfiguration.yaml
+++ b/helm/tests/values.withOtelcolCustomConfiguration.yaml
@@ -5,7 +5,7 @@ operator:
 
 sidecar:
   image:
-    repository: registry.localhost:5000/sumologic/tailing-sidecar
+    repository: registry.localhost:5000/sumologic/sidecar
     tag: test
 
   resources:

--- a/helm/tests/values.yaml
+++ b/helm/tests/values.yaml
@@ -5,7 +5,7 @@ operator:
 
 sidecar:
   image:
-    repository: registry.localhost:5000/sumologic/tailing-sidecar
+    repository: registry.localhost:5000/sumologic/sidecar
     tag: test
 
   resources:

--- a/kuttl-test-helm-certmanager.yaml
+++ b/kuttl-test-helm-certmanager.yaml
@@ -10,7 +10,7 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - registry.localhost:5000/sumologic/tailing-sidecar-operator:test
-  - registry.localhost:5000/sumologic/tailing-sidecar:test
+  - registry.localhost:5000/sumologic/sidecar:test
 commands: 
   - command: make -C ./operator deploy-cert-manager
   - command: helm upgrade --install test-release ./helm/tailing-sidecar-operator -f ./helm/tests/values.withCertManager.yaml -n tailing-sidecar-system --create-namespace

--- a/kuttl-test-helm-fluentbit-custom-configuration.yaml
+++ b/kuttl-test-helm-fluentbit-custom-configuration.yaml
@@ -10,7 +10,7 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - registry.localhost:5000/sumologic/tailing-sidecar-operator:test
-  - registry.localhost:5000/sumologic/tailing-sidecar:test
+  - registry.localhost:5000/sumologic/sidecar:test
 commands: 
   - command: helm upgrade --install test-release ./helm/tailing-sidecar-operator -f ./helm/tests/values.withFluentBitCustomConfiguration.yaml -n tailing-sidecar-system --create-namespace
   - command: make e2e-wait-until-operator-ready

--- a/kuttl-test-helm-otelcol-custom-configuration.yaml
+++ b/kuttl-test-helm-otelcol-custom-configuration.yaml
@@ -10,7 +10,7 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - registry.localhost:5000/sumologic/tailing-sidecar-operator:test
-  - registry.localhost:5000/sumologic/tailing-sidecar:test
+  - registry.localhost:5000/sumologic/sidecar:test
 commands: 
   - command: helm upgrade --install test-release ./helm/tailing-sidecar-operator -f ./helm/tests/values.withOtelcolCustomConfiguration.yaml -n tailing-sidecar-system --create-namespace
   - command: make e2e-wait-until-operator-ready

--- a/kuttl-test-helm.yaml
+++ b/kuttl-test-helm.yaml
@@ -10,7 +10,7 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - registry.localhost:5000/sumologic/tailing-sidecar-operator:test
-  - registry.localhost:5000/sumologic/tailing-sidecar:test
+  - registry.localhost:5000/sumologic/sidecar:test
 commands: 
   - command: helm upgrade --install test-release ./helm/tailing-sidecar-operator -f ./helm/tests/values.yaml -n tailing-sidecar-system --create-namespace
 

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -10,8 +10,8 @@ startKIND: true
 kindNodeCache: true
 kindContainers:
   - registry.localhost:5000/sumologic/tailing-sidecar-operator:test
-  - registry.localhost:5000/sumologic/tailing-sidecar:test
+  - registry.localhost:5000/sumologic/sidecar:test
 commands: 
   - command: make -C ./operator deploy-cert-manager
-  - command: make -C ./operator deploy IMG="registry.localhost:5000/sumologic/tailing-sidecar-operator:test" TAILING_SIDECAR_IMG="registry.localhost:5000/sumologic/tailing-sidecar:test"
+  - command: make -C ./operator deploy IMG="registry.localhost:5000/sumologic/tailing-sidecar-operator:test" TAILING_SIDECAR_IMG="registry.localhost:5000/sumologic/sidecar:test"
   - command: make e2e-wait-until-operator-ready


### PR DESCRIPTION
chore: rename sidecar image in tests to not indicate that the image is related to fluentbit and otelcol