### PR TITLE
chore: prepare release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.11.0] - 2024-03-25
+
+- feat: build ubi images [#654]
+- add affinity config for operator pod [#670]
+- build(deps): bump Fluent Bit from 2.2.2 to 3.0.0 [#672]
+
+[#654]: https://github.com/SumoLogic/tailing-sidecar/pull/654
+[#670]: https://github.com/SumoLogic/tailing-sidecar/pull/670
+[#672]: https://github.com/SumoLogic/tailing-sidecar/pull/672
+[v0.11.0]: https://github.com/SumoLogic/tailing-sidecar/releases/v0.11.0
+
 ## [v0.10.0] - 2024-02-14
 
 - feat(operator): add proper health checks [#608]

--- a/helm/tailing-sidecar-operator/Chart.yaml
+++ b/helm/tailing-sidecar-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tailing-sidecar-operator
 description: Installs Tailing Sidecar Operator
 type: application
-version: 0.10.0
-appVersion: 0.10.0
+version: 0.11.0
+appVersion: 0.11.0
 keywords:
   - tailing-sidecar
   - k8s-logging


### PR DESCRIPTION
## [v0.11.0] - 2024-03-25

- feat: build ubi images [#654]
- add affinity config for operator pod [#670]
- build(deps): bump Fluent Bit from 2.2.2 to 3.0.0 [#672]