### PR TITLE
Make running forks a bit easier

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build-fluentbit-sidecar-ghcr:
-    if: env.BUILD_GHCR
+    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +57,7 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-fluentbit-sidecar-ecr:
-    if: env.BUILD_ECR
+    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +91,7 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-fluentbit-sidecar-dockerhub:
-    if: env.BUILD_DOCKERHUB
+    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -165,7 +165,7 @@ jobs:
         working-directory: ./sidecar/otelcol
 
   build-operator-ghcr:
-    if: env.BUILD_GHCR
+    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
         working-directory: ./operator
 
   build-operator-ecr:
-    if: env.BUILD_ECR
+    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -242,7 +242,7 @@ jobs:
         working-directory: ./operator
 
   build-operator-dockerhub:
-    if: env.BUILD_DOCKERHUB
+    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -280,7 +280,7 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
-    if: env.PUSH_HELM
+    if: env.PUSH_HELM == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -7,17 +7,22 @@ on:
       - 'release-v[0-9]+.[0-9]+'
 
 env:
+  BUILD_GHCR: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
   OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
+  BUILD_ECR: ${{ vars.BUILD_ECR || 'true' }}
   ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
   SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
+  BUILD_DOCKERHUB: ${{ vars.BUILD_DOCKERHUB || 'true' }}
   SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "main"
+  PUSH_HELM: ${{ vars.PUSH_HELM || 'true'}}
 
 jobs:
-  build-fluentbit-sidecar:
+  build-fluentbit-sidecar-ghcr:
+    if: env.BUILD_GHCR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +56,22 @@ jobs:
         run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
+  build-fluentbit-sidecar-ecr:
+    if: env.BUILD_ECR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Log in to AWS Public ECR to publish tailing sidecar image
         run: make login-ecr
         env:
@@ -69,6 +90,22 @@ jobs:
         run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
+  build-fluentbit-sidecar-dockerhub:
+    if: env.BUILD_DOCKERHUB
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -127,7 +164,8 @@ jobs:
           make release-dev
         working-directory: ./sidecar/otelcol
 
-  build-operator:
+  build-operator-ghcr:
+    if: env.BUILD_GHCR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -165,6 +203,26 @@ jobs:
         run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
+  build-operator-ecr:
+    if: env.BUILD_ECR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Log in to AWS Public ECR to publish tailing sidecar operator image
         run: make login-ecr
         env:
@@ -183,6 +241,26 @@ jobs:
         run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
+  build-operator-dockerhub:
+    if: env.BUILD_DOCKERHUB
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running dev build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -202,6 +280,7 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
+    if: env.PUSH_HELM
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -7,22 +7,17 @@ on:
       - 'release-v[0-9]+.[0-9]+'
 
 env:
-  BUILD_GHCR: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
   OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
-  BUILD_ECR: ${{ vars.BUILD_ECR || 'true' }}
   ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
   SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
-  BUILD_DOCKERHUB: ${{ vars.BUILD_DOCKERHUB || 'true' }}
   SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "main"
-  PUSH_HELM: ${{ vars.PUSH_HELM || 'true'}}
 
 jobs:
   build-fluentbit-sidecar-ghcr:
-    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -57,7 +52,6 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-fluentbit-sidecar-ecr:
-    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -91,7 +85,6 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-fluentbit-sidecar-dockerhub:
-    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -165,7 +158,6 @@ jobs:
         working-directory: ./sidecar/otelcol
 
   build-operator-ghcr:
-    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -204,7 +196,6 @@ jobs:
         working-directory: ./operator
 
   build-operator-ecr:
-    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -242,7 +233,6 @@ jobs:
         working-directory: ./operator
 
   build-operator-dockerhub:
-    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -280,7 +270,6 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
-    if: env.PUSH_HELM == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -7,13 +7,13 @@ on:
       - 'release-v[0-9]+.[0-9]+'
 
 env:
-  SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"
-  OPERATOR_IMAGE: "ghcr.io/sumologic/tailing-sidecar-operator"
-  ECR_URL: public.ecr.aws/sumologic
-  SIDECAR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-dev"
-  OPERATOR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-operator-dev"
-  SIDECAR_IMAGE_DOCKERHUB: "sumologic/tailing-sidecar-dev"
-  OPERATOR_IMAGE_DOCKERHUB: "sumologic/tailing-sidecar-operator-dev"
+  SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
+  OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
+  ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
+  SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
+  OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
+  SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
+  OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "main"
 
 jobs:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -6,14 +6,11 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  BUILD_GHCR: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
   OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
-  BUILD_ECR: ${{ vars.BUILD_GHCR || 'true' }}
   ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
   SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
-  BUILD_DOCKERHUB: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "latest"
@@ -21,7 +18,6 @@ env:
 
 jobs:
   build-sidecar-ghcr:
-    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +52,6 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-sidecar-ecr:
-    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +85,6 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-sidecar-dockerhub:
-    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +118,6 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-operator-ghcr:
-    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +156,6 @@ jobs:
         working-directory: ./operator
 
   build-operator-ecr:
-    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +192,6 @@ jobs:
         working-directory: ./operator
 
   build-operator-dockerhub:
-    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -237,7 +228,6 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
-    if: env.PUSH_HELM == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -14,7 +14,6 @@ env:
   SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "latest"
-  PUSH_HELM: ${{ vars.PUSH_HELM || 'true'}}
 
 jobs:
   build-sidecar-ghcr:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -6,13 +6,13 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
-  SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"
-  OPERATOR_IMAGE: "ghcr.io/sumologic/tailing-sidecar-operator"
-  ECR_URL: public.ecr.aws/sumologic
-  SIDECAR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar"
-  OPERATOR_IMAGE_ECR: "public.ecr.aws/sumologic/tailing-sidecar-operator"
-  SIDECAR_IMAGE_DOCKERHUB: "sumologic/tailing-sidecar"
-  OPERATOR_IMAGE_DOCKERHUB: "sumologic/tailing-sidecar-operator"
+  SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
+  OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
+  ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
+  SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
+  OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
+  SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
+  OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "latest"
 
 jobs:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -6,17 +6,22 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 env:
+  BUILD_GHCR: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE: ${{ vars.OVERRIDE_SIDECAR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar' }}
   OPERATOR_IMAGE: ${{ vars.OVERRIDE_OPERATOR_IMAGE || 'ghcr.io/sumologic/tailing-sidecar-operator' }}
+  BUILD_ECR: ${{ vars.BUILD_GHCR || 'true' }}
   ECR_URL: ${{ vars.OVERRIDE_ECR_URL || 'public.ecr.aws/sumologic' }}
   SIDECAR_IMAGE_ECR: ${{ vars.OVERRIDE_SIDECAR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_ECR:  ${{ vars.OVERRIDE_OPERATOR_IMAGE_ECR || 'public.ecr.aws/sumologic/tailing-sidecar-operator-dev' }}
+  BUILD_DOCKERHUB: ${{ vars.BUILD_GHCR || 'true' }}
   SIDECAR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_SIDECAR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-dev' }}
   OPERATOR_IMAGE_DOCKERHUB: ${{ vars.OVERRIDE_OPERATOR_IMAGE_DOCKERHUB || 'sumologic/tailing-sidecar-operator-dev' }}
   LATEST_TAG: "latest"
+  PUSH_HELM: ${{ vars.PUSH_HELM || 'true'}}
 
 jobs:
-  build-sidecar:
+  build-sidecar-ghcr:
+    if: env.BUILD_GHCR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +55,22 @@ jobs:
         run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
+  build-sidecar-ecr:
+    if: env.BUILD_ECR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Log in to AWS Public ECR to publish tailing sidecar image
         run: make login-ecr
         env:
@@ -68,6 +89,22 @@ jobs:
         run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
+  build-sidecar-dockerhub:
+    if: env.BUILD_DOCKERHUB
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -86,7 +123,8 @@ jobs:
         run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
-  build-operator:
+  build-operator-ghcr:
+    if: env.BUILD_GHCR
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -124,6 +162,25 @@ jobs:
         run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
+  build-operator-ecr:
+    if: env.BUILD_ECR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Log in to AWS Public ECR to publish tailing sidecar operator image
         run: make login-ecr
         env:
@@ -142,6 +199,25 @@ jobs:
         run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
+  build-operator-dockerhub:
+    if: env.BUILD_DOCKERHUB
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.20'
+      - name: Extract tag
+        id: extract_tag
+        run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT
+      - name: Print container tag
+        run: echo "Running release build for ${{ steps.extract_tag.outputs.tag }}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@v3.1.0
         with:
@@ -161,6 +237,7 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
+    if: env.PUSH_HELM
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-sidecar-ghcr:
-    if: env.BUILD_GHCR
+    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-sidecar-ecr:
-    if: env.BUILD_ECR
+    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-sidecar-dockerhub:
-    if: env.BUILD_DOCKERHUB
+    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
         working-directory: ./sidecar/fluentbit
 
   build-operator-ghcr:
-    if: env.BUILD_GHCR
+    if: env.BUILD_GHCR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -163,7 +163,7 @@ jobs:
         working-directory: ./operator
 
   build-operator-ecr:
-    if: env.BUILD_ECR
+    if: env.BUILD_ECR == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -200,7 +200,7 @@ jobs:
         working-directory: ./operator
 
   build-operator-dockerhub:
-    if: env.BUILD_DOCKERHUB
+    if: env.BUILD_DOCKERHUB == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -237,7 +237,7 @@ jobs:
         working-directory: ./operator
 
   push-helm-chart:
-    if: env.PUSH_HELM
+    if: env.PUSH_HELM == 'true'
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is to make it easier to run a fork with limited changes to the github actions.

- Splits up jobs so if a user doesn't have ECR configured for example the others can still execute
- Allows for setting OVERRIDE_ image tags at the repo level so a fork user can push to their own registries.

For context I'm changing the output format in the fluent plugin [like this](https://github.com/SumoLogic/tailing-sidecar/commit/415e73357f16785e55c87037b0e61401a346b631#diff-b7ae1d427675ac284016de0198138fef319e1ea2f71fa4b5bfcf2896bf08b247R43-R51) but would still like to have an easy process for syncing the fork without dealing with conflicts every time.