### PR TITLE
build: downgrade sidecar to Go 1.20

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-v[0-9]+.[0-9]+'
+      - 'dev-build/*'
 
 env:
   SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"

--- a/sidecar/fluentbit/Dockerfile
+++ b/sidecar/fluentbit/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3 as go-builder
+FROM golang:1.20.14 as go-builder
 RUN mkdir /build
 ADD ./out_gstdout /build/
 WORKDIR /build


### PR DESCRIPTION
https://github.com/golang/go/issues/62440 is still unresolved in newer Go versions, and it causes crashes in some circumstances.

I've also added dev builds on branches prefixed with `dev-build/`, like we do in other projects.