### PR TITLE
chore: set version and release_number labels in ubi image

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - 'release-v[0-9]+.[0-9]+'
+      - 'dev-build/*'
 
 env:
   SIDECAR_IMAGE: "ghcr.io/sumologic/tailing-sidecar"
@@ -42,13 +43,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
       - name: Log in to AWS Public ECR to publish tailing sidecar image
@@ -60,13 +61,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push to ECR tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag to ECR
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag to ECR
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
       - name: Login to Docker Hub
@@ -78,13 +79,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
   build-otelcol-sidecar:
@@ -156,13 +157,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
       - name: Log in to AWS Public ECR to publish tailing sidecar operator image
@@ -174,13 +175,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push to ECR tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag to ECR
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag to ECR
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
       - name: Login to Docker Hub
@@ -192,13 +193,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
   push-helm-chart:

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -41,13 +41,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
       - name: Log in to AWS Public ECR to publish tailing sidecar image
@@ -59,13 +59,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push to ECR tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag to ECR
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag to ECR
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
       - name: Login to Docker Hub
@@ -77,13 +77,13 @@ jobs:
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Build and push tailing sidecar ubi image
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar image with latest tag
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
       - name: Push tailing sidecar ubi image with latest tag
-        run: make build-push-ubi TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
   build-operator:
@@ -115,13 +115,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
       - name: Log in to AWS Public ECR to publish tailing sidecar operator image
@@ -133,13 +133,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push to ECR tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag to ECR
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag to ECR
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE_ECR }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
       - name: Login to Docker Hub
@@ -151,13 +151,13 @@ jobs:
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Build and push tailing sidecar operator ubi image
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
+        run: make build-push-ubi VERSION=${{ steps.extract_tag.outputs.tag }} IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator
       - name: Push tailing sidecar operator image with latest tag
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
       - name: Push tailing sidecar operator ubi image with latest tag
-        run: make build-push-ubi IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
+        run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./operator
 
   push-helm-chart:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -28,6 +28,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# UBI image variables
+RELEASE_NUMBER ?= "1"
+
 # Run tests
 # Set default shell as bash
 SHELL := /bin/bash
@@ -175,7 +178,11 @@ generate: controller-gen
 
 # Build the docker image
 docker-build:
-	docker build . -f ${DOCKERFILE} -t ${IMG}
+	docker build . \
+		--build-arg RELEASE_NUMBER=$(RELEASE_NUMBER) \
+		--build-arg VERSION=$(VERSION) \
+		-f ${DOCKERFILE} \
+		-t ${IMG}
 
 # Push the docker image
 docker-push:

--- a/sidecar/fluentbit/Makefile
+++ b/sidecar/fluentbit/Makefile
@@ -15,7 +15,11 @@ VERSION ?= ""
 all: build push
 
 build:
-	docker build --tag $(TAG) --file ${DOCKERFILE} .
+	docker build \
+	--build-arg RELEASE_NUMBER=$(RELEASE_NUMBER) \
+	--build-arg VERSION=$(VERSION) \
+	--tag $(TAG) \
+	--file ${DOCKERFILE} .
 
 build-test-image: build
 
@@ -23,8 +27,6 @@ run: build
 	docker run --rm -it \
 		-v $(DIR_TO_TAIL):/tmp/host \
 		-v $(FLUENT_BIT_DB_DIR):/tailing-sidecar/var \
-		--build-arg RELEASE_NUMBER=$(RELEASE_NUMBER) \
-		--build-arg VERSION=$(VERSION) \
 		--env "PATH_TO_TAIL=/tmp/host/$(FILES_PATTERN)" \
 		--env "LOG_LEVEL=${LOG_LEVEL}" $(TAG)
 

--- a/sidecar/fluentbit/Makefile
+++ b/sidecar/fluentbit/Makefile
@@ -9,7 +9,7 @@ root_dir := $(dir $(abspath $(mkfile_path)/..))
 
 TAG ?= "localhost:32000/sumologic/tailing-sidecar:latest"
 DOCKERFILE ?= Dockerfile
-RELEASE_NUMBER ?= 1\
+RELEASE_NUMBER ?= 1
 VERSION ?= ""
 
 all: build push

--- a/sidecar/fluentbit/Makefile
+++ b/sidecar/fluentbit/Makefile
@@ -9,6 +9,8 @@ root_dir := $(dir $(abspath $(mkfile_path)/..))
 
 TAG ?= "localhost:32000/sumologic/tailing-sidecar:latest"
 DOCKERFILE ?= Dockerfile
+RELEASE_NUMBER ?= 1\
+VERSION ?= ""
 
 all: build push
 
@@ -21,6 +23,8 @@ run: build
 	docker run --rm -it \
 		-v $(DIR_TO_TAIL):/tmp/host \
 		-v $(FLUENT_BIT_DB_DIR):/tailing-sidecar/var \
+		--build-arg RELEASE_NUMBER=$(RELEASE_NUMBER) \
+		--build-arg VERSION=$(VERSION) \
 		--env "PATH_TO_TAIL=/tmp/host/$(FILES_PATTERN)" \
 		--env "LOG_LEVEL=${LOG_LEVEL}" $(TAG)
 


### PR DESCRIPTION
```
preflight check container ghcr.io/sumologic/tailing-sidecar-operator:3cf903d-ubi --platform=linux/arm64
time="2024-06-03T14:10:14+02:00" level=info msg="certification library version" version="1.9.6 <commit: 354d10d9af8b5a64c7c2230a6656186957c3ed9f>"
time="2024-06-03T14:10:14+02:00" level=info msg="running checks for ghcr.io/sumologic/tailing-sidecar-operator:3cf903d-ubi for platform linux/arm64"
time="2024-06-03T14:10:14+02:00" level=info msg="target image" image="ghcr.io/sumologic/tailing-sidecar-operator:3cf903d-ubi"
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=HasLicense result=PASSED
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=HasUniqueTag result=PASSED
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=HasRequiredLabel result=PASSED
time="2024-06-03T14:10:20+02:00" level=info msg="USER nonroot:nonroot specified that is non-root"
time="2024-06-03T14:10:20+02:00" level=info msg="check completed" check=RunAsNonRoot result=PASSED
time="2024-06-03T14:10:23+02:00" level=info msg="check completed" check=HasModifiedFiles result=PASSED
time="2024-06-03T14:10:25+02:00" level=info msg="check completed" check=BasedOnUbi result=PASSED
time="2024-06-03T14:10:25+02:00" level=info msg="This image's tag 3cf903d-ubi will be paired with digest sha256:558fd2bf2063eb3e44f7e4079ebd1e1ceaf9231395a09bf41897e85978fed5f0 once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
{
    "image": "ghcr.io/sumologic/tailing-sidecar-operator:3cf903d-ubi",
    "passed": true,
    "test_library": {
        "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
        "version": "1.9.6",
        "commit": "354d10d9af8b5a64c7c2230a6656186957c3ed9f"
    },
    "results": {
        "passed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
            },
            {
                "name": "HasUniqueTag",
                "elapsed_time": 0,
                "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
            },
            {
                "name": "LayerCountAcceptable",
                "elapsed_time": 0,
                "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
            },
            {
                "name": "HasNoProhibitedPackages",
                "elapsed_time": 22,
                "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
            },
            {
                "name": "HasRequiredLabel",
                "elapsed_time": 0,
                "description": "Checking if the required labels (name, vendor, version, release, summary, description) are present in the container metadata."
            },
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
            },
            {
                "name": "HasModifiedFiles",
                "elapsed_time": 3510,
                "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
            },
            {
                "name": "BasedOnUbi",
                "elapsed_time": 1776,
                "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
            }
        ],
        "failed": [],
        "errors": []
    }
}
time="2024-06-03T14:10:25+02:00" level=info msg="Preflight result: PASSED"
```