### PR TITLE
deps(operator): bump go to 1.22

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             sidecar/otelcol/.otelcol-builder.yaml
             sidecar/otelcol/.goreleaser.yaml
@@ -135,7 +135,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
+          cache-dependency-path: operator/go.sum
       - name: Extract tag
         id: extract_tag
         run: echo "tag=$(echo $(git describe --tags --always))" >> $GITHUB_OUTPUT

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -40,7 +40,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
+          cache-dependency-path: operator/go.sum
       - name: Run tests for tailing sidecar operator
         working-directory: ./operator
         run: make test
@@ -56,7 +57,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             sidecar/otelcol/.otelcol-builder.yaml
             sidecar/otelcol/.goreleaser.yaml
@@ -82,7 +83,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             .otelcol-builder.yaml
             .goreleaser.yaml
@@ -113,7 +114,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             .otelcol-builder.yaml
             .goreleaser.yaml
@@ -144,7 +145,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             sidecar/otelcol/.otelcol-builder.yaml
             sidecar/otelcol/.goreleaser.yaml
@@ -175,7 +176,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache-dependency-path: |
             sidecar/otelcol/.otelcol-builder.yaml
             sidecar/otelcol/.goreleaser.yaml

--- a/.github/workflows/release_builds.yml
+++ b/.github/workflows/release_builds.yml
@@ -93,7 +93,8 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version: '1.22'
+          cache-dependency-path: operator/go.sum
       - name: Extract tag
         id: extract_tag
         run: echo "tag=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_OUTPUT

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -19,7 +19,7 @@ DOCKERFILE ?= Dockerfile
 TAILING_SIDECAR_IMG ?= localhost:32000/sumologic/tailing-sidecar:latest
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:crdVersions={v1},trivialVersions=true"
+CRD_OPTIONS ?= "crd:crdVersions={v1}"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -199,6 +199,7 @@ build-push-ubi:
 	$(MAKE) docker-build DOCKERFILE=${DOCKERFILE}.ubi IMG=${IMG}-ubi
 	$(MAKE) docker-push DOCKERFILE=${DOCKERFILE}.ubi IMG=${IMG}-ubi
 
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 # find or download controller-gen
 # download controller-gen if necessary
 controller-gen:
@@ -208,7 +209,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/SumoLogic/tailing-sidecar/operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
This should unblock #707.

I've also upgraded controller-tools, as it paniced when compiled with Go 1.22.