### PR TITLE
deps: upgrade kube-rbac-proxy to v0.18.0

### DIFF
--- a/helm/tailing-sidecar-operator/values.yaml
+++ b/helm/tailing-sidecar-operator/values.yaml
@@ -67,7 +67,7 @@ kubeRbacProxy:
   image:
     pullPolicy: IfNotPresent
     repository: quay.io/brancz/kube-rbac-proxy
-    tag: v0.11.0
+    tag: v0.18.0
   resources:
     limits:
       cpu: 500m
@@ -82,7 +82,7 @@ kubeRbacProxy:
 webhook:
   failurePolicy: Ignore
   reinvocationPolicy: Never
-  
+
   objectSelector: {}
     # matchLabels:
     #   tailing-sidecar: "true"

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -1,4 +1,4 @@
-# This patch inject a sidecar container which is a HTTP proxy for the 
+# This patch inject a sidecar container which is a HTTP proxy for the
 # controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
 apiVersion: apps/v1
 kind: Deployment
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
This fixes CVE-2023-45288 and CVE-2022-21698.