### PR TITLE
fix: Remove otel builds until we upgrade it to the latest version

### DIFF
--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -88,46 +88,6 @@ jobs:
         run: make build-push-ubi VERSION=${{ env.LATEST_TAG }} TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ env.LATEST_TAG }}
         working-directory: ./sidecar/fluentbit
 
-  build-otelcol-sidecar:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          filter: tree:0
-          fetch-depth: 0
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-          cache-dependency-path: |
-            sidecar/otelcol/.otelcol-builder.yaml
-            sidecar/otelcol/.goreleaser.yaml
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.2.0
-        with:
-          registry: ghcr.io
-          username: USERNAME
-          password: ${{ secrets.CR_PAT }}
-      - name: Log in to AWS Public ECR
-        run: make login-ecr
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_TAILING_SIDECAR_OTEL_DEV }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_TAILING_SIDECAR_OTEL_DEV }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_TAILING_SIDECAR_OTEL_DEV }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TAILING_SIDECAR_OTEL_DEV }}
-      - name: Build and push otelcol sidecar image
-        run: |
-          make install-builder
-          make release-dev
-        working-directory: ./sidecar/otelcol
-
   build-operator:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/dev_builds.yml
+++ b/.github/workflows/dev_builds.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_TAILING_SIDECAR_DEV }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TAILING_SIDECAR_DEV }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_TAILING_SIDECAR_OTEL_DEV }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD_TAILING_SIDECAR_OTEL_DEV }}
       - name: Build and push tailing sidecar multiplatform image
         run: make build-push-multiplatform TAG=${{ env.SIDECAR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./sidecar/fluentbit
@@ -148,8 +148,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3.2.0
         with:
-          username: ${{ secrets.DOCKERHUB_LOGIN_TAILING_SIDECAR_OPERATOR_DEV }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TAILING_SIDECAR_OPERATOR_DEV }}
+          username: ${{ secrets.DOCKERHUB_LOGIN_TAILING_SIDECAR_OTEL_DEV }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD_TAILING_SIDECAR_OTEL_DEV }}
       - name: Build and push tailing sidecar operator multiplatform image
         run: make build-push-multiplatform IMG=${{ env.OPERATOR_IMAGE_DOCKERHUB }}:${{ steps.extract_tag.outputs.tag }}
         working-directory: ./operator

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -49,35 +49,13 @@ jobs:
         working-directory: ./operator
         run: make manager
 
-  build-otelcol-sidecar:
-    name: Build otelcol sidecar
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup go
-        uses: actions/setup-go@v5
-        with:
-          go-version: '1.22'
-          cache-dependency-path: |
-            sidecar/otelcol/.otelcol-builder.yaml
-            sidecar/otelcol/.goreleaser.yaml
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.1.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.7.1
-      - name: Build otelcol sidecar
-        working-directory: ./sidecar/otelcol
-        run: |
-          make install-builder
-          make build
-
   test-without-helm:
     name: Test resources created without Helm chart
     runs-on: ubuntu-20.04
     timeout-minutes: 15
     strategy:
       matrix:
-        sidecar: [fluentbit, otelcol]
+        sidecar: [fluentbit]
     steps:
       - uses: actions/checkout@v4
       - name: Setup go
@@ -108,7 +86,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        sidecar: [fluentbit, otelcol]
+        sidecar: [fluentbit]
     steps:
       - uses: actions/checkout@v4
       - name: Setup go
@@ -139,7 +117,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        sidecar: [fluentbit, otelcol]
+        sidecar: [fluentbit]
     steps:
       - uses: actions/checkout@v4
       - name: Setup go
@@ -170,7 +148,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        sidecar: [fluentbit, otelcol]
+        sidecar: [fluentbit]
     steps:
       - uses: actions/checkout@v4
       - name: Setup go


### PR DESCRIPTION
fix: Remove otel builds until we upgrade it to the latest version

This PR could be reverted, once we successfully upgrade the otel sidecar to the latest version.