### PR TITLE
updated golang and fluent-bit images on tailing-sidecar ubi image

### DIFF
--- a/sidecar/fluentbit/Dockerfile.ubi
+++ b/sidecar/fluentbit/Dockerfile.ubi
@@ -1,11 +1,11 @@
-FROM golang:1.23rc1 AS go-builder
+FROM golang:1.24.3 AS go-builder
 RUN mkdir /build
 ADD ./out_gstdout /build/
 WORKDIR /build
 RUN make all
 
 # ToDo: build and use the latest fluent-bit image
-FROM public.ecr.aws/sumologic/fluent-bit:3.0.7-ubi
+FROM public.ecr.aws/sumologic/fluent-bit:4.0.1-ubi
 
 ARG VERSION=${VERSION}
 ARG RELEASE_NUMBER=${RELEASE_NUMBER}


### PR DESCRIPTION
<img width="1619" alt="Screenshot 2025-05-07 at 11 08 07" src="https://github.com/user-attachments/assets/f9409c2e-c0f7-441a-b958-ac8a930f0c82" />
