### PR TITLE
bump fluentbit version to latest

### DIFF
--- a/sidecar/fluentbit/Dockerfile
+++ b/sidecar/fluentbit/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
 RUN find /dpkg/ -type d -empty -delete && \
     rm -r /dpkg/usr/share/doc/
 
-FROM fluent/fluent-bit:4.0.1
+FROM fluent/fluent-bit:4.0.5
 ENV LOG_LEVEL=warning
 
 # Copy the libraries from the extractor stage into root


### PR DESCRIPTION
We need the [input graceperiod](https://github.com/fluent/fluent-bit/pull/9952) feature that was added in 4.0.3.

Rather than go to 4.0.3 I figured it would be reasonable to bump this to the latest, which is 4.0.5