### PR TITLE
ci: improve dependency management with Dependabot and Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,21 @@ updates:
       interval: "daily"
       time: "06:27"
       timezone: "Europe/Warsaw"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/sidecar/otelcol"
+    schedule:
+      interval: "daily"
+      time: "06:27"
+      timezone: "Europe/Warsaw"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/operator"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Europe/Warsaw",
+  "schedule": ["before 7am"],
+  "labels": ["dependencies"],
+  // Disable managers that Dependabot already covers
+  "enabledManagers": [
+    "helm-values"
+  ],
+  "helm-values": {
+    "fileMatch": [
+      "helm/tailing-sidecar-operator/values\\.yaml"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add Dependabot Docker ecosystem entry for `/sidecar/otelcol` to track base image updates (`alpine`, `sumologic-otel-collector`, `ubi-minimal`) that were previously unmonitored
- Add `docker-base-images` grouping to both Docker entries so base image bumps arrive as a single PR per directory
- Add minimal Renovate config (`helm-values` manager only) to track pinned image tags in Helm `values.yaml` (e.g. `kube-rbac-proxy:v0.21.2`) — Dependabot cannot parse image tags from Helm values files

## Why both tools?

Dependabot handles Dockerfiles, Go modules, and GitHub Actions well. Renovate fills the one gap — pinned image tags inside `helm/tailing-sidecar-operator/values.yaml`. The Renovate config is scoped to `enabledManagers: ["helm-values"]` only, so there is no overlap or duplicate PRs.

## Test plan

- [ ] Verify Dependabot picks up Docker updates for `/sidecar/otelcol` after merge
- [ ] Install [Renovate GitHub App](https://github.com/apps/renovate) on the repo and verify it opens a Dependency Dashboard issue
- [ ] Confirm Renovate only creates PRs for Helm values image tags, not for ecosystems Dependabot covers