### PR TITLE
chore: add renovate workflow for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,21 @@ updates:
       interval: "daily"
       time: "06:27"
       timezone: "Europe/Warsaw"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/sidecar/otelcol"
+    schedule:
+      interval: "daily"
+      time: "06:27"
+      timezone: "Europe/Warsaw"
+    groups:
+      docker-base-images:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/operator"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,21 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '30 18 * * 2'  # every Tuesday at 18:30 UTC (12:00 AM IST)
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Renovate run
+        uses: renovatebot/github-action@v46.1.10
+        env:
+          LOG_LEVEL: debug
+          RENOVATE_REPOSITORIES: SumoLogic/tailing-sidecar
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          configurationFile: renovate.json5

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,8 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "timezone": "Europe/Warsaw",
-  "schedule": ["before 7am"],
   "labels": ["dependencies"],
   // Disable managers that Dependabot already covers
   "enabledManagers": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "timezone": "Europe/Warsaw",
+  "schedule": ["before 7am"],
+  "labels": ["dependencies"],
+  // Disable managers that Dependabot already covers
+  "enabledManagers": [
+    "helm-values"
+  ],
+  "helm-values": {
+    "fileMatch": [
+      "helm/tailing-sidecar-operator/values\\.yaml"
+    ]
+  }
+}


### PR DESCRIPTION
Summary                                                                                                                                                                          
                                                                                                                                                                                   
  - Add Dependabot Docker ecosystem entry for /sidecar/otelcol to track base image updates (alpine, sumologic-otel-collector, ubi-minimal)                                         
  - Group Docker base image updates into single PRs per directory to reduce PR noise                                                                                               
  - Run Renovate as a self-hosted GitHub Action (weekly on Tuesdays) to manage Helm values image tag updates that Dependabot cannot handle                                         
                                                                                                                                                                                   
  Motivation                                                                                                                                                                       
                                                                                                                                                                                   
  Dependabot doesn't support updating pinned image tags inside Helm values.yaml files. Renovate fills that gap via the helm-values manager. Running it as a GitHub Action (similar 
  to https://github.com/SumoLogic/sumologic-otel-collector) gives us more control over scheduling without depending on the hosted Renovate App.
                                                                                                                                                