### PR TITLE
chore: update Renovate to run daily and align with kubernetes-collection config

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,9 +1,28 @@
-name: Renovate
-
+name: Renovate-scheduler
 on:
   schedule:
-    - cron: '30 18 * * 2'  # every Tuesday at 18:30 UTC (12:00 AM IST)
+    - cron: "30 18 * * *" # every day at 18:30 UTC (12:00 AM IST)
   workflow_dispatch:
+    inputs:
+      logLevel:
+        description: "Log level"
+        type: choice
+        default: "info"
+        options:
+          - "info"
+          - "debug"
+          - "warn"
+      dryRun:
+        description: "Dry-run: full (simulate PRs), lookup (check updates only), extract (parse deps only)"
+        type: choice
+        default: ""
+        options:
+          - ""
+          - "full"
+          - "lookup"
+          - "extract"
+
+concurrency: renovate
 
 jobs:
   renovate:
@@ -11,11 +30,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Renovate run
-        uses: renovatebot/github-action@v46.1.10
-        env:
-          LOG_LEVEL: debug
-          RENOVATE_REPOSITORIES: SumoLogic/tailing-sidecar
+      - name: Validate Renovate config
+        uses: rinchsan/renovate-config-validator@v0.2.1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          pattern: renovate.json5
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+
+      - name: Renovate run
+        uses: renovatebot/github-action@v46.1.13
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun || '' }}
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_USERNAME: "renovatebot-sumologic[bot]"
+          RENOVATE_GIT_AUTHOR: "renovatebot-sumologic[bot] <279692411+renovatebot-sumologic[bot]@users.noreply.github.com>"
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           configurationFile: renovate.json5

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,8 +3,11 @@
   "extends": [
     "config:recommended"
   ],
+  "recreateWhen": "always",
+  "prHourlyLimit": 10,
   "labels": ["dependencies"],
-  // Disable managers that Dependabot already covers
+  "commitMessageAction": "bump",
+  "commitMessageExtra": "{{#if isSingleVersion}}from {{{currentValue}}} to {{{newValue}}}{{/if}}",
   "enabledManagers": [
     "helm-values"
   ],
@@ -12,5 +15,12 @@
     "fileMatch": [
       "helm/tailing-sidecar-operator/values\\.yaml"
     ]
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Add chore(deps) prefix to all dependency update commits",
+      "matchPackagePatterns": [".*"],
+      "commitMessagePrefix": "chore(deps):"
+    }
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "dependencyDashboardApproval": false,
   "recreateWhen": "always",
   "prHourlyLimit": 10,
   "labels": ["dependencies"],


### PR DESCRIPTION
## Summary
- Change Renovate schedule from weekly (Tuesday) to daily (18:30 UTC)
- Add workflow_dispatch inputs for logLevel and dryRun
- Add concurrency guard, config validation, and GitHub App token auth
- Align renovate.json5 with kubernetes-collection patterns (recreateWhen, prHourlyLimit, commitMessageAction, chore(deps) prefix)

## Prerequisites
- `RENOVATE_APP_ID` and `RENOVATE_PRIVATE_KEY` secrets must be configured in the repo

## Test plan
- [ ] Verify secrets are available in the repo
- [ ] Trigger workflow manually with dry-run mode to validate config