### PR TITLE
fix: remove invalid helm-values manager config from renovate.json5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,11 +14,6 @@
   enabledManagers: [
     'helm-values',
   ],
-  'helm-values': {
-    managerFilePatterns: [
-      '/helm/tailing-sidecar-operator/values\\.yaml/',
-    ],
-  },
   packageRules: [
     {
       description: 'Add chore(deps) prefix to all dependency update commits',


### PR DESCRIPTION
## Summary

- Removes the invalid top-level `helm-values` config block with `managerFilePatterns` which causes Renovate validation to fail with: `Invalid configuration option: helm-values.managerFilePatterns`
- The helm-values manager's default pattern (`/(^|/)values\.ya?ml$/`) already matches `helm/tailing-sidecar-operator/values.yaml`, so no custom override is needed
- Renovate was failing with invalid config after config migration: https://github.com/SumoLogic/tailing-sidecar/actions/runs/25636825008/job/75250095137
- works in this branch https://github.com/SumoLogic/tailing-sidecar/actions/runs/25654406982/job/75299385649
## Test plan

- [ ] Verify Renovate validation passes (`renovate-config-validator` or the Renovate GitHub Action)
- [ ] Confirm Renovate still detects dependencies in `helm/tailing-sidecar-operator/values.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)